### PR TITLE
We don't need to keep the file handle around.

### DIFF
--- a/storage/mfile_test.go
+++ b/storage/mfile_test.go
@@ -14,15 +14,18 @@ func BenchmarkWrites(b *testing.B) {
 	n := f.Name()
 	f.Close()
 	os.Remove(n)
-	err = CreateMFile(n, 1<<23)
+	err = CreateMFile(n, 1<<23) // 8 MB
 	if err != nil {
 		b.Fatal(err)
 	}
 	defer os.Remove(n)
-	m, err := OpenMFile(n, 1024)
+	m, err := OpenMFile(n, 1024) // Block Size: 1 KB
 	defer m.Close()
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		// Cycle through the all the blocks in the file.
+		//   (file size / block size = 8192 blocks = 1<<13)
 		m.WriteBlock(uint64(i%(1<<13)), []byte("some data"))
 		m.Flush()
 	}


### PR DESCRIPTION
See [this StackOverflow question](http://stackoverflow.com/questions/17490033/do-i-need-to-keep-a-file-open-after-calling-mmap-on-it).

I also added some comments.
