### PR TITLE
Single Block Write-Cache

### DIFF
--- a/cmd/agroctl/mkfs.go
+++ b/cmd/agroctl/mkfs.go
@@ -28,8 +28,8 @@ var mkfsCommand = &cobra.Command{
 }
 
 func init() {
-	mkfsCommand.Flags().StringVarP(&blockSizeStr, "block-size", "", "8KiB", "size of all data blocks in this filesystem")
-	mkfsCommand.Flags().StringVarP(&blockSpec, "block-spec", "", "crc", "default replication/error correction applied to blocks in this filesystem")
+	mkfsCommand.Flags().StringVarP(&blockSizeStr, "block-size", "", "512KiB", "size of all data blocks in this filesystem")
+	mkfsCommand.Flags().StringVarP(&blockSpec, "block-spec", "", "rep=2,crc", "default replication/error correction applied to blocks in this filesystem")
 	mkfsCommand.Flags().IntVarP(&inodeReplication, "inode-replication", "", 3, "default number of times to replicate inodes across the cluster")
 }
 


### PR DESCRIPTION
Upping the block size to 512K, I ran out of disk space quickly. This is because without GC, we were:

Load block, write 32K, commit to cluster, load same block, write 32 more K, commit to cluster... each one of these overwrites taking up space.

This fixes that by keeping the most recently written block uncommitted, until sync or until the next block is needed.
