### PR TITLE
server: use old inode volume when removing file

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -278,7 +278,7 @@ func (s *server) removeFile(p agro.Path) error {
 		return err
 	}
 	live := bs.GetLiveINodes()
-	_, err = s.mds.SetFileINode(p, agro.INodeRef{})
+	_, err = s.mds.SetFileINode(p, agro.NewINodeRef(ref.Volume(), 0))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
SetFileINode expects that the ref's volume matches the path's volume.
without this i got 'inodeRef volume not for given path volume' when
trying to remove using memory metadata.
