### PR TITLE
gc/rebalance: refactor gc into a simple check interface, merge rebalance and GC threads

### DIFF
--- a/server/distributor.go
+++ b/server/distributor.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/coreos/agro"
 	"github.com/coreos/agro/models"
+	"github.com/coreos/agro/server/gc"
 	"github.com/coreos/agro/server/rebalance"
 	"github.com/dgryski/go-tinylfu"
 )
@@ -67,7 +68,8 @@ func newDistributor(srv *server, addr string, listen bool) (*distributor, error)
 	d.ringWatcherChan = make(chan struct{})
 	go d.ringWatcher(d.rebalancerChan)
 	d.client = newDistClient(d)
-	d.rebalancer = rebalance.NewRebalancer(d, d.blocks, d.client)
+	g := gc.NewGCController(d.srv.mds)
+	d.rebalancer = rebalance.NewRebalancer(d, d.blocks, d.client, g)
 	d.rebalancerChan = make(chan struct{})
 	go d.rebalanceTicker(d.rebalancerChan)
 	return d, nil

--- a/server/distributor_rebalance.go
+++ b/server/distributor_rebalance.go
@@ -43,35 +43,62 @@ func (d *distributor) rebalanceTicker(closer chan struct{}) {
 	n := 0
 	total := 0
 	time.Sleep(time.Duration(250+rand.Intn(250)) * time.Millisecond)
+	volIdx := 0
+	var volset []string
+	var err error
 exit:
 	for {
-		timeout := 10 * time.Duration(n+1) * time.Millisecond
-		select {
-		case <-closer:
-			break exit
-		case <-time.After(timeout):
-			written, err := d.rebalancer.Tick()
-			if d.ring.Version() != d.rebalancer.VersionStart() {
-				// Something is changed -- we are now rebalancing
-				d.srv.peerInfo.Rebalancing = true
-			}
-			total += written
-			d.srv.peerInfo.LastRebalanceBlocks = uint64(total)
-			if err == io.EOF {
-				// Good job, sleep well, I'll most likely rebalance you in the morning.
-				d.srv.peerInfo.LastRebalanceFinish = time.Now().UnixNano()
-				total = 0
-				finishver := d.rebalancer.VersionStart()
-				if finishver == d.ring.Version() {
-					d.srv.peerInfo.Rebalancing = false
-				}
-				time.Sleep(time.Duration(rand.Intn(5)) * time.Second)
-				continue exit
-			} else if err != nil {
-				// This is usually really bad
+		if volIdx == len(volset) {
+			volIdx = 0
+			volset, err = d.srv.mds.GetVolumes()
+			if err != nil {
 				clog.Error(err)
 			}
-			n = written
+			time.Sleep(time.Duration(rand.Intn(250)) * time.Millisecond)
+			continue
 		}
+		vol, err := d.srv.mds.GetVolumeID(volset[volIdx])
+		if err != nil {
+			clog.Error(err)
+			continue
+		}
+		err = d.rebalancer.UseVolume(vol)
+		if err != nil {
+			clog.Error(err)
+			continue
+		}
+		clog.Debugf("starting rebalance/gc for %s", volset[volIdx])
+	volume:
+		for {
+			timeout := 10 * time.Duration(n+1) * time.Millisecond
+			select {
+			case <-closer:
+				break exit
+			case <-time.After(timeout):
+				written, err := d.rebalancer.Tick()
+				if d.ring.Version() != d.rebalancer.VersionStart() {
+					// Something is changed -- we are now rebalancing
+					d.srv.peerInfo.Rebalancing = true
+				}
+				total += written
+				d.srv.peerInfo.LastRebalanceBlocks = uint64(total)
+				if err == io.EOF {
+					// Good job, sleep well, I'll most likely rebalance you in the morning.
+					d.srv.peerInfo.LastRebalanceFinish = time.Now().UnixNano()
+					total = 0
+					finishver := d.rebalancer.VersionStart()
+					if finishver == d.ring.Version() {
+						d.srv.peerInfo.Rebalancing = false
+					}
+					break volume
+				} else if err != nil {
+					// This is usually really bad
+					clog.Error(err)
+				}
+				n = written
+			}
+		}
+		time.Sleep(time.Duration(rand.Intn(5)) * time.Second)
+		volIdx++
 	}
 }

--- a/server/distributor_rpc.go
+++ b/server/distributor_rpc.go
@@ -71,10 +71,6 @@ func (d *distributor) RebalanceCheck(ctx context.Context, req *models.RebalanceC
 	defer d.mut.Unlock()
 	for i, x := range req.BlockRefs {
 		p := agro.BlockFromProto(x)
-		if d.srv.gc.RecentlyGCed(p) {
-			out[i] = true
-			continue
-		}
 		ok, err := d.blocks.HasBlock(ctx, p)
 		if err != nil {
 			clog.Error(err)

--- a/server/gc/blocks_by_inode.go
+++ b/server/gc/blocks_by_inode.go
@@ -2,157 +2,50 @@ package gc
 
 import (
 	"sync"
-	"time"
 
-	"github.com/tylertreat/BoomFilters"
-	"golang.org/x/net/context"
+	"github.com/RoaringBitmap/roaring"
 
 	"github.com/coreos/agro"
 )
 
 type blocksByINode struct {
-	mut        sync.Mutex
-	mds        agro.MetadataService
-	blocks     agro.BlockStore
-	stopChan   chan bool
-	forceChan  chan bool
-	doneChan   chan bool
-	last       time.Time
-	gcBloom    *boom.InverseBloomFilter
-	bloomSize  uint
-	bloomCount uint
+	mut     sync.RWMutex
+	deadmap *roaring.Bitmap
+	vol     agro.VolumeID
+	mds     agro.MetadataService
 }
 
-const bbiBloomGCSize = 300 * 1024 * 1024 * 1024 //100GiB
-
-func NewBlocksByINodeGC(mds agro.MetadataService, blocks agro.BlockStore) GC {
-	size := uint(bbiBloomGCSize / blocks.BlockSize())
-	return &blocksByINode{
-		mds:       mds,
-		blocks:    blocks,
-		last:      time.Unix(0, 0),
-		gcBloom:   boom.NewInverseBloomFilter(size),
-		bloomSize: size,
-	}
+func NewBlocksByINodeGC(mds agro.MetadataService) GC {
+	return &blocksByINode{mds: mds}
 }
 
-func (b *blocksByINode) Start() {
-	if b.stopChan != nil {
-		return
-	}
-	sc := make(chan bool)
-	fc := make(chan bool)
-	dc := make(chan bool)
-	b.stopChan = sc
-	b.forceChan = fc
-	b.doneChan = dc
-	go blocksByINodeMain(b, sc, fc, dc)
-}
-
-func (b *blocksByINode) Stop() {
-	if b.stopChan == nil {
-		return
-	}
-	close(b.stopChan)
-	close(b.forceChan)
-	<-b.doneChan
-	b.stopChan = nil
-	b.doneChan = nil
-	b.forceChan = nil
-}
-
-func (b *blocksByINode) Force() {
-	if b.forceChan != nil {
-		b.forceChan <- true
-	}
-}
-
-func (b *blocksByINode) LastComplete() time.Time {
-	return b.last
-}
-
-func (b *blocksByINode) RecentlyGCed(ref agro.BlockRef) bool {
-	ok := b.gcBloom.Test(ref.ToBytes())
-	if ok {
-		return true
-	}
-	deadmap, held, err := b.mds.GetVolumeLiveness(ref.Volume())
+func (b *blocksByINode) PrepVolume(vid agro.VolumeID) error {
+	b.mut.Lock()
+	defer b.mut.Unlock()
+	b.vol = vid
+	deadmap, held, err := b.mds.GetVolumeLiveness(vid)
 	if err != nil {
-		return false
+		return err
 	}
 	for _, x := range held {
 		deadmap.AndNot(x)
 	}
-	if deadmap.Contains(uint32(ref.INode)) {
-		b.gcBloom.Add(ref.ToBytes())
+	b.deadmap = deadmap
+	return nil
+}
+
+func (b *blocksByINode) IsDead(ref agro.BlockRef) bool {
+	b.mut.RLock()
+	defer b.mut.RUnlock()
+	if ref.Volume() != b.vol {
+		clog.Error("checking dead ref we haven't prepared for")
+		return false
+	}
+
+	if b.deadmap.Contains(uint32(ref.INode)) {
 		return true
 	}
 	return false
 }
 
-func (b *blocksByINode) gc(volume string) {
-	vid, err := b.mds.GetVolumeID(volume)
-	if err != nil {
-		clog.Errorf("bbi: got error getting volume ID for %s %v", volume, err)
-	}
-	deadmap, held, err := b.mds.GetVolumeLiveness(vid)
-	if err != nil {
-		clog.Errorf("bbi: got error gcing volume %s %v", volume, err)
-	}
-	for _, x := range held {
-		deadmap.AndNot(x)
-	}
-	it := b.blocks.BlockIterator()
-	for it.Next() {
-		ref := it.BlockRef()
-		if ref.Volume() == vid && deadmap.Contains(uint32(ref.INode)) {
-			b.blocks.DeleteBlock(context.TODO(), ref)
-			b.gcBloom.Add(ref.ToBytes())
-			b.bloomCount++
-		}
-	}
-	err = it.Err()
-	if err != nil {
-		clog.Errorf("bbi: error in blockref iteration")
-	}
-	if b.bloomCount >= b.bloomSize {
-		// Flush it if it's getting too full
-		b.gcBloom = boom.NewInverseBloomFilter(b.bloomSize)
-		b.bloomCount = 0
-	}
-}
-
-func blocksByINodeMain(b *blocksByINode, stop chan bool, force chan bool, done chan bool) {
-	clog.Debug("bbi: starting blocksByInode")
-all:
-	for {
-		forced := false
-		select {
-		case <-time.After(DefaultGCWait):
-			clog.Trace("bbi: top of gc")
-		case <-stop:
-			break all
-		case <-force:
-			forced = true
-			clog.Debug("bbi: forcing")
-		}
-		volumes, err := b.mds.GetVolumes()
-		if err != nil {
-			clog.Error("couldn't get volumes", err)
-		}
-		for _, v := range volumes {
-			b.gc(v)
-			if forced {
-				continue
-			}
-			select {
-			case <-time.After(DefaultGCWait):
-			case <-stop:
-				break all
-			}
-		}
-		b.last = time.Now()
-	}
-	clog.Debug("bbi: ending blocksByInode")
-	close(done)
-}
+func (b *blocksByINode) Clear() {}

--- a/server/local_server.go
+++ b/server/local_server.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/coreos/agro"
 	"github.com/coreos/agro/models"
-	"github.com/coreos/agro/server/gc"
 )
 
 func mkdirsFor(dir string) error {
@@ -56,12 +55,10 @@ func NewServer(cfg agro.Config, metadataServiceKind, blockStoreKind string) (agr
 		peersMap:      make(map[string]*models.PeerInfo),
 		openINodeRefs: make(map[string]map[agro.INodeID]int),
 		cfg:           cfg,
-		gc:            gc.NewGCController(mds, blocks),
 		peerInfo: &models.PeerInfo{
 			UUID: mds.UUID(),
 		},
 	}
-	s.gc.Start()
 	return s, nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -12,7 +12,6 @@ import (
 	"github.com/RoaringBitmap/roaring"
 	"github.com/coreos/agro"
 	"github.com/coreos/agro/models"
-	"github.com/coreos/agro/server/gc"
 
 	// Register drivers
 	_ "github.com/coreos/agro/metadata/memory"
@@ -36,7 +35,6 @@ type server struct {
 
 	heartbeating    bool
 	replicationOpen bool
-	gc              gc.GC
 }
 
 func (s *server) FileEntryForPath(p agro.Path) (agro.VolumeID, *models.FileEntry, error) {
@@ -186,9 +184,6 @@ func (s *server) GetVolumes() ([]string, error) {
 func (s *server) Close() error {
 	for _, c := range s.closeChans {
 		close(c)
-	}
-	if s.gc != nil {
-		s.gc.Stop()
 	}
 	err := s.mds.Close()
 	if err != nil {


### PR DESCRIPTION
Having a single "upkeep" thread is way, way simpler to coordinate, kills data at the right time, never retransmits it, uses less memory and less code, less memory thrashing --- all in all, a huge coordination win.

The only reason it was the other way before was that GC was written before the new balancer.
