### PR TITLE
block/aoe, cmd/torusblk: allow AoE server major and minor address con…

### DIFF
--- a/block/aoe/aoe.go
+++ b/block/aoe/aoe.go
@@ -26,7 +26,32 @@ type Server struct {
 	minor uint8
 }
 
-func NewServer(b *block.BlockVolume) (*Server, error) {
+// ServerOptions specifies options for a Server.
+type ServerOptions struct {
+	// Major and Minor specify the major and minor address of an AoE server.
+	// Typically, all AoE devices on a single server will share the same
+	// major address, but have different minor addresses.
+	//
+	// It is important to note that all AoE servers on the same layer 2
+	// network must have different major and minor addresses.
+	Major uint16
+	Minor uint8
+}
+
+// DefaultServerOptions is the default ServerOptions configuration used
+// by NewServer when none is specified.
+var DefaultServerOptions = &ServerOptions{
+	Major: 1,
+	Minor: 1,
+}
+
+// NewServer creates a new Server which utilizes the specified block volume.
+// If options is nil, DefaultServerOptions will be used.
+func NewServer(b *block.BlockVolume, options *ServerOptions) (*Server, error) {
+	if options == nil {
+		options = DefaultServerOptions
+	}
+
 	f, err := b.OpenBlockFile()
 	if err != nil {
 		return nil, err
@@ -39,8 +64,8 @@ func NewServer(b *block.BlockVolume) (*Server, error) {
 	as := &Server{
 		dfs:   b,
 		dev:   fd,
-		major: 1,
-		minor: 1,
+		major: options.Major,
+		minor: options.Minor,
 	}
 
 	return as, nil

--- a/cmd/torusblk/aoe.go
+++ b/cmd/torusblk/aoe.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -13,13 +15,26 @@ import (
 )
 
 var aoeCommand = &cobra.Command{
-	Use:   "aoe VOLUME INTERFACE",
+	Use:   "aoe VOLUME INTERFACE MAJOR MINOR",
 	Short: "serve a volume over AoE [EXPERIMENTAL]",
-	Run:   aoeAction,
+	Long: strings.TrimSpace(`
+Serve a volume over AoE using the specified network interface and AoE
+major and minor addresses.
+
+It is important to note that all AoE servers on the same layer 2 network
+must have different major and minor addresses.
+
+An example of serving two volumes using AoE on the same server over the
+eth0 network interface:
+
+	torusblk aoe vol01 eth0 1 1
+	torusblk aoe vol02 eth0 1 2
+`),
+	Run: aoeAction,
 }
 
 func aoeAction(cmd *cobra.Command, args []string) {
-	if len(args) != 2 {
+	if len(args) != 4 {
 		cmd.Usage()
 		os.Exit(1)
 	}
@@ -28,6 +43,18 @@ func aoeAction(cmd *cobra.Command, args []string) {
 
 	vol := args[0]
 	ifname := args[1]
+	maj := args[2]
+	min := args[3]
+
+	major, err := strconv.ParseUint(maj, 10, 16)
+	if err != nil {
+		die("Failed to parse major address %q: %v\n", maj, err)
+	}
+
+	minor, err := strconv.ParseUint(min, 10, 8)
+	if err != nil {
+		die("Failed to parse minor address %q: %v\n", min, err)
+	}
 
 	blockvol, err := block.OpenBlockVolume(srv, vol)
 	if err != nil {
@@ -41,7 +68,10 @@ func aoeAction(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	as, err := aoe.NewServer(blockvol)
+	as, err := aoe.NewServer(blockvol, &aoe.ServerOptions{
+		Major: uint16(major),
+		Minor: uint8(minor),
+	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to crate AoE server: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
…figuration

Tested with two volumes.

```
$ torusctl volume list             
+-------------+---------+
| VOLUME NAME |  SIZE   |
+-------------+---------+
| vol01       | 2.0 GiB |
| vol02       | 4.0 GiB |
+-------------+---------+
```

```
$ sudo torusblk aoe vol01 br0 1 1
$ sudo torusblk aoe vol02 br0 1 2 
```

```
$ sudo aoe-stat
      e1.1         2.147GB       eth1 8704  up            
      e1.2         4.294GB       eth1 8704  up
```

Feel free to point out stylistic issues as I'm not yet familiar with the project.  I just use the typical tools like `golint`, `go vet`, etc.