### PR TITLE
*: Use glide in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,10 +28,12 @@ _testmain.go
 *.swp
 *.swo
 
-# Binaries in root dir
-torusd
-torusctl
-torusblk
+# Binaries
+bin
+
+# Since torus can be used as a package, don't commit the vendor directory.
+# For background see: https://groups.google.com/forum/#!topic/golang-dev/4FfTBfN2YaI
+vendor
 
 # local-cluster information
 /local-cluster

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,13 @@ go:
   - tip
 
 install:
-  # Install our tracked dependencies
-  - go get github.com/Masterminds/glide
-  - glide install
+  - make vendor
 
 script:
-  - go fmt $(glide novendor)
-  - go vet $(glide novendor)
-  - go test $(glide novendor)
-  - make
+  - make fmt
+  - make vet
+  - make test
+  - make build
 
 matrix:
   allow_failures:

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,32 @@
 ifeq ($(origin VERSION), undefined)
   VERSION != git rev-parse --short HEAD
 endif
+GOOS=$(shell go env GOOS)
+GOARCH=$(shell go env GOARCH)
 REPOPATH = github.com/coreos/torus
 
-build:
-	go build -ldflags "-X $(REPOPATH).Version=$(VERSION)" ./cmd/torusd 
-	go build -ldflags "-X $(REPOPATH).Version=$(VERSION)" ./cmd/torusctl 
-	go build -ldflags "-X $(REPOPATH).Version=$(VERSION)" ./cmd/torusblk 
+build: vendor
+	go build -o bin/torusd -ldflags "-X $(REPOPATH).Version=$(VERSION)" ./cmd/torusd
+	go build -o bin/torusctl -ldflags "-X $(REPOPATH).Version=$(VERSION)" ./cmd/torusctl
+	go build -o bin/torusblk -ldflags "-X $(REPOPATH).Version=$(VERSION)" ./cmd/torusblk
+
+test: bin/glide
+	go test $(shell ./bin/glide novendor)
+
+vet: bin/glide
+	go vet $(shell ./bin/glide novendor)
+
+fmt: bin/glide
+	go fmt $(shell ./bin/glide novendor)
 
 run:
-	./torusd --etcd 127.0.0.1:2379 --debug --debug-init --peer-address 127.0.0.1:40000
+	./bin/torusd --etcd 127.0.0.1:2379 --debug --debug-init --peer-address 127.0.0.1:40000
 
 clean:
-	rm -rf ./local-cluster
+	rm -rf ./local-cluster ./bin/torus*
 
 cleanall: clean
-	rm -rf /tmp/etcd
+	rm -rf /tmp/etcd bin vendor
 
 etcdrun:
 	./local/etcd/etcd --data-dir /tmp/etcd
@@ -26,3 +37,13 @@ run3:
 release:
 	mkdir -p release
 	goxc -d ./release -tasks-=go-vet,go-test -os="linux darwin" -pv=$(VERSION) -build-ldflags="-X $(REPOPATH).Version=$(VERSION)" -resources-include="README.md,docs,LICENSE,contrib" -main-dirs-exclude="vendor,cmd/ringtool"
+
+vendor: bin/glide
+	./bin/glide install
+
+bin/glide:
+	@echo "Downloading glide"
+	mkdir -p bin
+	curl -L https://github.com/Masterminds/glide/releases/download/0.10.2/glide-0.10.2-$(GOOS)-$(GOARCH).tar.gz | tar -xz -C bin
+	mv bin/$(GOOS)-$(GOARCH)/glide bin/glide
+	rm -r bin/$(GOOS)-$(GOARCH)

--- a/Procfile
+++ b/Procfile
@@ -1,6 +1,6 @@
-torus1: ./torusd --etcd 127.0.0.1:2379 --debug --debug-init --port 4321 --data-dir local-cluster/torus1  --peer-address http://127.0.0.1:40000 --size 5GiB --auto-join --host 127.0.0.1
-torus2: ./torusd --etcd 127.0.0.1:2379 --debug --debug-init --port 4322 --data-dir local-cluster/torus2 --peer-address http://127.0.0.1:40001 --size 5GiB --writelevel one --auto-join --host 127.0.0.1
-torus3: ./torusd --etcd 127.0.0.1:2379 --debug --debug-init --port 4323 --data-dir local-cluster/torus3 --peer-address http://127.0.0.1:40002 --size 5GiB --read-cache-size=200MiB --auto-join --host 127.0.0.1
-#torus4: ./torusd --etcd 127.0.0.1:2379 --debug --debug-init --port 4324 --data-dir local-cluster/torus4 --peer-address 127.0.0.1:40003 --size 5GiB --read-cache-size=200MiB --auto-join
-#torus5: ./torusd --etcd 127.0.0.1:2379 --debug --debug-init --port 4325 --data-dir local-cluster/torus5 --peer-address 127.0.0.1:40004 --size 5GiB --read-cache-size=200MiB --auto-join
-#torusblk: sudo ./torusblk nbd blockvol /dev/nbd2 --write-level local --write-cache-size 1GiB
+torus1: ./bin/torusd --etcd 127.0.0.1:2379 --debug --debug-init --port 4321 --data-dir local-cluster/torus1  --peer-address http://127.0.0.1:40000 --size 5GiB --auto-join --host 127.0.0.1
+torus2: ./bin/torusd --etcd 127.0.0.1:2379 --debug --debug-init --port 4322 --data-dir local-cluster/torus2 --peer-address http://127.0.0.1:40001 --size 5GiB --writelevel one --auto-join --host 127.0.0.1
+torus3: ./bin/torusd --etcd 127.0.0.1:2379 --debug --debug-init --port 4323 --data-dir local-cluster/torus3 --peer-address http://127.0.0.1:40002 --size 5GiB --read-cache-size=200MiB --auto-join --host 127.0.0.1
+#torus4: ./bin/torusd --etcd 127.0.0.1:2379 --debug --debug-init --port 4324 --data-dir local-cluster/torus4 --peer-address 127.0.0.1:40003 --size 5GiB --read-cache-size=200MiB --auto-join
+#torus5: ./bin/torusd --etcd 127.0.0.1:2379 --debug --debug-init --port 4325 --data-dir local-cluster/torus5 --peer-address 127.0.0.1:40004 --size 5GiB --read-cache-size=200MiB --auto-join
+#torusblk: sudo ./bin/torusblk nbd blockvol /dev/nbd2 --write-level local --write-cache-size 1GiB


### PR DESCRIPTION
When building from source, don't recommend using "go get". Instead
clone and populate the vendor directory using glide.

This updates the perceived issue with #189

The "go get" was removed because it downloads a lot of packages but
not enough to actually build torus. See comment [here](
https://github.com/coreos/torus/pull/190#issuecomment-223345034).

Since this introduces another binary, I've moved the default build to
use a "bin" directory.

cc @barakmich 