### PR TITLE
*: turn on race detector for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build: vendor
 	go build -o bin/torusblk -ldflags "-X $(REPOPATH).Version=$(VERSION)" ./cmd/torusblk
 
 test: bin/glide
-	go test $(shell ./bin/glide novendor)
+	go test --race $(shell ./bin/glide novendor)
 
 vet: bin/glide
 	go vet $(shell ./bin/glide novendor)

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -108,6 +108,10 @@ func (s *Server) updatePeerMap() {
 		clog.Warningf("couldn't update peerlist: %s", err)
 	}
 	promServerPeers.Set(float64(len(peers)))
+
+	s.mut.Lock()
+	defer s.mut.Unlock()
+
 	for _, p := range peers {
 		s.peersMap[p.UUID] = p
 	}

--- a/metadata/temp/temp.go
+++ b/metadata/temp/temp.go
@@ -94,7 +94,9 @@ func (t *Client) GetLease() (int64, error) { return 1, nil }
 func (t *Client) GetPeers() (torus.PeerInfoList, error) {
 	t.srv.mut.Lock()
 	defer t.srv.mut.Unlock()
-	return t.srv.peers, nil
+	peers := make(torus.PeerInfoList, len(t.srv.peers))
+	copy(peers, t.srv.peers)
+	return peers, nil
 }
 
 func (t *Client) RegisterPeer(_ int64, pi *models.PeerInfo) error {

--- a/storage/mfile.go
+++ b/storage/mfile.go
@@ -112,6 +112,8 @@ func (m *mfileBlock) numBlocks() uint64 {
 }
 
 func (m *mfileBlock) UsedBlocks() uint64 {
+	m.mut.RLock()
+	defer m.mut.RUnlock()
 	return uint64(len(m.refIndex))
 }
 


### PR DESCRIPTION
This PR turns on the race detector for all go tests and fixes some
code that currently triggers race errors.

closes #201