### PR TITLE
Add build status and godoc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Torus
+[![Build Status](https://travis-ci.org/coreos/torus.svg?branch=master)](https://travis-ci.org/coreos/torus)
+[![GoDoc](https://godoc.org/github.com/coreos/torus?status.svg)](https://godoc.org/github.com/coreos/torus)
 
 Torus is an open source project for distributed storage coordinated through [etcd](https://github.com/coreos/etcd).
 


### PR DESCRIPTION
Minor update to show travis-ci project build status as well as godoc link.