### PR TITLE
fixed endpoint selector for postgres service

### DIFF
--- a/contrib/kubernetes/postgres-oneshot.yaml
+++ b/contrib/kubernetes/postgres-oneshot.yaml
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       labels:
-        app: postgres-torus
+        name: postgres-torus
     spec:
       containers:
       - image: postgres


### PR DESCRIPTION
The existing selector doesn't match the postgres-torus pod. If you run 

```
kubectl get endpoints
NAME                  ENDPOINTS          AGE
postgres-torus        <none>             48m
```

The pod should be available in the ENDPOINTS

After changing  the label on the deployment pod you can see the pod

```
kubectl get endpoints
NAME                  ENDPOINTS          AGE
postgres-torus        172.23.59.7:5432   49m
```
:shipit: 