### PR TITLE
Fixed the psql db seed

### DIFF
--- a/contrib/kubernetes/README.md
+++ b/contrib/kubernetes/README.md
@@ -58,7 +58,7 @@ kubectl create -f postgres-oneshot.yaml
 
 ```
 TORUSPOD=$(kubectl get pods -l app=postgres-torus -o name | cut -d/ -f2)
-kubectl exec $TORUSPOD -- psql postgres -U postgres < test-data.sql
+kubectl exec -i $TORUSPOD -- psql postgres -U postgres < test-data.sql
 kubectl exec $TORUSPOD -- psql postgres -U postgres -c 'select * from films'
 ```
 


### PR DESCRIPTION
The initial psql database seed needs stdin to read from the file redirect `< test-data.sql`

This simply adds `-i` to the exec command to send stdin to the pod.

Thanks @barakmich for the help figuring it out.