### PR TITLE
Using app= selector instead of name

### DIFF
--- a/contrib/kubernetes/postgres-oneshot.yaml
+++ b/contrib/kubernetes/postgres-oneshot.yaml
@@ -18,7 +18,7 @@ kind: Deployment
 metadata:
   name: postgres-torus
   labels:
-    name: postgres-torus
+    app: postgres-torus
 spec:
   replicas: 1
   template:

--- a/contrib/kubernetes/postgres-oneshot.yaml
+++ b/contrib/kubernetes/postgres-oneshot.yaml
@@ -11,7 +11,7 @@ spec:
       targetPort: postgres-client
       nodePort: 30432
   selector:
-    name: postgres-torus
+    app: postgres-torus
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       labels:
-        name: postgres-torus
+        app: postgres-torus
     spec:
       containers:
       - image: postgres


### PR DESCRIPTION
After reading through the rest of the README example instead of changing all of the README searches I switched the service selector, deployment, and pod labels to app=postgres-torus.

The rest of the README works for me now.