### PR TITLE
block/aoe: use io.Closer in Device interface

### DIFF
--- a/block/aoe/device.go
+++ b/block/aoe/device.go
@@ -15,11 +15,11 @@ var (
 )
 
 type Device interface {
+	io.Closer
 	io.ReadWriteSeeker
 	io.ReaderAt
 	io.WriterAt
 	Sync() error
-	Close() error
 	aoe.Identifier
 }
 


### PR DESCRIPTION
Easy one.  Might as well use the built-in interface instead of duplicating it on our own.