### PR TITLE
blockset.go: add BlockReconstructor interface for erasure-encoding

### DIFF
--- a/blockset.go
+++ b/blockset.go
@@ -24,6 +24,12 @@ type Blockset interface {
 	String() string
 }
 
+// BlockReconstructor can reconstruct a block in a Blockset.
+type BlockReconstructor interface {
+	// ReconstructBlock reconstructs the ith block in the Blockset.
+	ReconstructBlock(ctx context.Context, inde INodeRef, i int) error
+}
+
 type BlockLayerKind int
 
 type BlockLayer struct {


### PR DESCRIPTION
For https://github.com/coreos/torus/issues/165 part 1.

I use `Reconstruct` instead of `Rebuild` since people usually `Reconstruct` in reed-solomon world.

@barakmich I am not sure if we should add this into the existing BlockSet interface. Most of the blockset implementation (as least for today) should not implement Reconstruct.