### PR TITLE
metadata/etcd: register wipe function

### DIFF
--- a/metadata/etcd/etcd.go
+++ b/metadata/etcd/etcd.go
@@ -41,6 +41,7 @@ var (
 func init() {
 	torus.RegisterMetadataService("etcd", newEtcdMetadata)
 	torus.RegisterMetadataInit("etcd", initEtcdMetadata)
+	torus.RegisterMetadataWipe("etcd", wipeEtcdMetadata)
 	torus.RegisterSetRing("etcd", setRing)
 
 	prometheus.MustRegister(promAtomicRetries)


### PR DESCRIPTION
Not sure if the wipe function registration was intentionally removed or it was just missing.

The wipeEtcdMetadata function was already implemented but not registered
causing a panic calling `torusctl wipe`.

This patch registers the wipe function.