### PR TITLE
Add AoE BPF filter tests

### DIFF
--- a/block/aoe/aoe_test.go
+++ b/block/aoe/aoe_test.go
@@ -133,7 +133,10 @@ func testBPFProgram(t *testing.T, s *Server, h *aoe.Header) bool {
 		t.Fatal("failed to decode all BPF instructions")
 	}
 
-	vm := bpftest.New(filter)
+	vm, err := bpftest.New(filter)
+	if !ok {
+		t.Fatalf("failed to load BPF program: %v", err)
+	}
 
 	// Fill in empty AoE header fields not relevant to this test
 	h.Version = aoe.Version

--- a/glide.lock
+++ b/glide.lock
@@ -67,7 +67,7 @@ imports:
 - name: github.com/mdlayher/aoe
   version: 63bdfd7f5c50809059b7b6de1cf37c2e330c5f81
 - name: github.com/mdlayher/bpftest
-  version: eb43252a412e18bf0b21603ba9f4d593a4fd2d7a
+  version: 8ae8a42d6a3a54f815cfb0f207256d37ebcd8843
 - name: github.com/mdlayher/ethernet
   version: 28018267bba4d651e8e0fcbca8aae7c13f4ce4ae
 - name: github.com/mdlayher/raw

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 600f9bccc64e435d5f19687f42a8304f690cf961e90f183c2a9cd24848ae2533
-updated: 2016-06-02T13:17:43.759643711-07:00
+hash: 1a8f9ce91ec93454e953a2db2357e97d299dd42aae5c93d6a68ed34a1297545a
+updated: 2016-06-09T12:14:57.730504027-04:00
 imports:
 - name: github.com/barakmich/mmap-go
   version: c4bd255520e591ff7549ab916c59206da5735e56
@@ -66,6 +66,8 @@ imports:
   - pbutil
 - name: github.com/mdlayher/aoe
   version: 63bdfd7f5c50809059b7b6de1cf37c2e330c5f81
+- name: github.com/mdlayher/bpftest
+  version: eb43252a412e18bf0b21603ba9f4d593a4fd2d7a
 - name: github.com/mdlayher/ethernet
   version: 28018267bba4d651e8e0fcbca8aae7c13f4ce4ae
 - name: github.com/mdlayher/raw

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,6 +23,7 @@ import:
   - proto
 - package: github.com/kardianos/osext
 - package: github.com/mdlayher/aoe
+- package: github.com/mdlayher/bpftest
 - package: github.com/mdlayher/ethernet
 - package: github.com/mdlayher/raw
 - package: github.com/olekukonko/tablewriter


### PR DESCRIPTION
Adds my `bpftest` package to enable testing the BPF program in `block/aoe`, and adds some tests that prove it is working correctly.