### PR TITLE
distributor/storage: fix wrong nil error when writing fails on all peers

### DIFF
--- a/distributor/storage.go
+++ b/distributor/storage.go
@@ -229,7 +229,8 @@ func (d *Distributor) WriteBlock(ctx context.Context, i torus.BlockRef, data []b
 			}
 		}
 		if toWrite == peers.Replication {
-			return err
+			clog.Noticef("error WriteAll to all peers")
+			return torus.ErrNoPeer
 		}
 		clog.Warningf("only wrote block to %d/%d peers", toWrite, peers.Replication)
 	}


### PR DESCRIPTION
When writing a block fails an all peers a nil error is returned (since
err is nil in that scope).

This cause the volume to fail opening again since BlockFile.Sync
thinks that f.File.SyncINode() wrote the inode block to at least one
store and so it'll write the inode metadata. On next volume opening the
inode block cannot be retrieved leaving the volume inaccessible.

This patch fixes distributor/storage.WriteBlock to return an error if
writing the block fails on all the peers.

Should fix #250 