### PR TITLE
server: create new lease if expired

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -62,4 +62,7 @@ var (
 
 	// ErrLocked is returned if the resource is locked.
 	ErrLocked = errors.New("torus: locked")
+
+	// ErrLeaseNotFound is returned if the lease cannot be found.
+	ErrLeaseNotFound = errors.New("torus: lease not found")
 )

--- a/metadata.go
+++ b/metadata.go
@@ -41,6 +41,7 @@ type MetadataService interface {
 	WithContext(ctx context.Context) MetadataService
 
 	GetLease() (int64, error)
+	RenewLease(int64) error
 	RegisterPeer(lease int64, pi *models.PeerInfo) error
 	GetPeers() (PeerInfoList, error)
 

--- a/metadata/temp/temp.go
+++ b/metadata/temp/temp.go
@@ -90,7 +90,9 @@ func (t *Client) UUID() string {
 	return t.uuid
 }
 
-func (t *Client) GetLease() (int64, error) { return 1, nil }
+func (t *Client) GetLease() (int64, error)     { return 1, nil }
+func (t *Client) RenewLease(lease int64) error { return nil }
+
 func (t *Client) GetPeers() (torus.PeerInfoList, error) {
 	t.srv.mut.Lock()
 	defer t.srv.mut.Unlock()


### PR DESCRIPTION
If a server cannot communicate with etcd for a time greater then the lease
timeout (30s) its lease will expire and the server won't reregister
requiring it to be restarted.

This patch fixes this making the server, inside the heartbeat goroutine,
renew the current lease or create a new lease if expired and use this
one to register itself.

This should fix #252 and can be a starting point for option 2 in https://github.com/coreos/torus/issues/230#issuecomment-224092476.