### PR TITLE
#242 cmd/torusd: extend peer address parsing to avoid panic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ fmt: bin/glide
 	go fmt $(shell ./bin/glide novendor)
 
 run:
-	./bin/torusd --etcd 127.0.0.1:2379 --debug --debug-init --peer-address 127.0.0.1:40000
+	./bin/torusd --etcd 127.0.0.1:2379 --debug --debug-init --peer-address http://127.0.0.1:40000
 
 clean:
 	rm -rf ./local-cluster ./bin/torus*

--- a/cmd/torusd/main.go
+++ b/cmd/torusd/main.go
@@ -196,11 +196,19 @@ func runServer(cmd *cobra.Command, args []string) {
 	signal.Notify(signalChan, os.Interrupt)
 
 	if peerAddress != "" {
-		u, err := url.Parse(peerAddress)
+		var u *url.URL
+
+		u, err = url.Parse(peerAddress)
 		if err != nil {
 			fmt.Printf("Couldn't parse peer address %s: %s\n", peerAddress, err)
 			os.Exit(1)
 		}
+
+		if u.Scheme == "" {
+			fmt.Printf("Peer address %s does not have URL scheme (http:// or tdp://)\n", peerAddress)
+			os.Exit(1)
+		}
+
 		err = distributor.ListenReplication(srv, u)
 	} else {
 		err = distributor.OpenReplication(srv)

--- a/distributor/protocols/protocols.go
+++ b/distributor/protocols/protocols.go
@@ -1,6 +1,7 @@
 package protocols
 
 import (
+	"fmt"
 	"net/url"
 	"time"
 
@@ -42,6 +43,10 @@ func RegisterRPCListener(scheme string, newFunc RPCListenerFunc) {
 }
 
 func ListenRPC(url *url.URL, handler RPC, gmd torus.GlobalMetadata) (RPCServer, error) {
+	if rpcListeners[url.Scheme] == nil {
+		return nil, fmt.Errorf("Unknown ListenRPC protocol '%s'", url.Scheme)
+	}
+
 	return rpcListeners[url.Scheme](url, handler, gmd)
 }
 
@@ -58,5 +63,9 @@ func RegisterRPCDialer(scheme string, newFunc RPCDialerFunc) {
 }
 
 func DialRPC(url *url.URL, timeout time.Duration, gmd torus.GlobalMetadata) (RPC, error) {
+	if rpcDialers[url.Scheme] == nil {
+		return nil, fmt.Errorf("Unknown DialRPC protocol '%s'", url.Scheme)
+	}
+
 	return rpcDialers[url.Scheme](url, timeout, gmd)
 }


### PR DESCRIPTION
1. Added more checks of parsed peer-addr URL to prevent panic
2. Fixed error processing