### PR TITLE
ring: Append Ketama nodes, not panic on small rings

### DIFF
--- a/ring/ketama_test.go
+++ b/ring/ketama_test.go
@@ -1,0 +1,40 @@
+package ring
+
+import (
+	"testing"
+
+	"github.com/coreos/torus"
+	"github.com/coreos/torus/models"
+	"github.com/serialx/hashring"
+)
+
+func TestTinyPeer(t *testing.T) {
+	pi := torus.PeerInfoList{
+		&models.PeerInfo{
+			UUID:        "a",
+			TotalBlocks: 20 * 1024 * 1024 * 2,
+		},
+		&models.PeerInfo{
+			UUID:        "b",
+			TotalBlocks: 20 * 1024 * 1024 * 2,
+		},
+		&models.PeerInfo{
+			UUID:        "c",
+			TotalBlocks: 100 * 1024 * 2,
+		},
+	}
+	k := &ketama{
+		version: 1,
+		peers:   pi,
+		rep:     2,
+		ring:    hashring.NewWithWeights(pi.GetWeights()),
+	}
+	l, err := k.GetPeers(torus.BlockRef{
+		INodeRef: torus.NewINodeRef(3, 4),
+		Index:    5,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(l.Peers)
+}

--- a/ring/ring_main.go
+++ b/ring/ring_main.go
@@ -1,9 +1,12 @@
 package ring
 
 import (
+	"github.com/coreos/pkg/capnslog"
 	"github.com/coreos/torus"
 	"github.com/coreos/torus/models"
 )
+
+var clog = capnslog.NewPackageLogger("github.com/coreos/torus", "ring")
 
 const (
 	Empty torus.RingType = iota


### PR DESCRIPTION
The Ketama hash may not assign points to servers that are particularly
small compared to the total storage. This makes some sense -- they can't
cover much. However, this causes errors, and we need to return a full
permutation, so simply append the small ones as "overflow". Fixes #246.

Rings can also declare their replication factor as being higher than the
number of nodes they contain. This causes panics. Raise a warning when
such a ring is detected, but continue operation. Fixes #219.