### PR TITLE
block/aoe: remove unused io.{Reader,Writer}At methods from Device int…

### DIFF
--- a/block/aoe/device.go
+++ b/block/aoe/device.go
@@ -17,8 +17,6 @@ var (
 type Device interface {
 	io.Closer
 	io.ReadWriteSeeker
-	io.ReaderAt
-	io.WriterAt
 	Sync() error
 	aoe.Identifier
 }


### PR DESCRIPTION
…erface

Package `aoe` doesn't use these methods at all at the moment, so might as well make this interface a little smaller.