### PR TITLE
block/aoe: use new x/net/bpf.VM type in tests

### DIFF
--- a/block/aoe/aoe_test.go
+++ b/block/aoe/aoe_test.go
@@ -20,7 +20,6 @@ import (
 	_ "github.com/coreos/torus/storage"
 
 	"github.com/mdlayher/aoe"
-	"github.com/mdlayher/bpftest"
 	"github.com/mdlayher/ethernet"
 	"github.com/mdlayher/raw"
 	"golang.org/x/net/bpf"
@@ -194,7 +193,7 @@ func testBPFProgram(t *testing.T, s *Server, h *aoe.Header) bool {
 		t.Fatal("failed to decode all BPF instructions")
 	}
 
-	vm, err := bpftest.New(filter)
+	vm, err := bpf.NewVM(filter)
 	if !ok {
 		t.Fatalf("failed to load BPF program: %v", err)
 	}
@@ -220,12 +219,12 @@ func testBPFProgram(t *testing.T, s *Server, h *aoe.Header) bool {
 		t.Fatalf("failed to marshal Ethernet frame to binary: %v", err)
 	}
 
-	_, ok, err = vm.Run(fb)
+	out, err := vm.Run(fb)
 	if err != nil {
 		t.Fatalf("failed to run BPF program: %v", err)
 	}
 
-	return ok
+	return out > 0
 }
 
 // testRequest performs a single AoE request using the input request

--- a/glide.lock
+++ b/glide.lock
@@ -66,8 +66,6 @@ imports:
   - pbutil
 - name: github.com/mdlayher/aoe
   version: 63bdfd7f5c50809059b7b6de1cf37c2e330c5f81
-- name: github.com/mdlayher/bpftest
-  version: 8ae8a42d6a3a54f815cfb0f207256d37ebcd8843
 - name: github.com/mdlayher/ethernet
   version: 28018267bba4d651e8e0fcbca8aae7c13f4ce4ae
 - name: github.com/mdlayher/raw
@@ -105,7 +103,7 @@ imports:
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
-  version: c4c3ea71919de159c9e246d7be66deb7f0a39a58
+  version: 1961d9def2b2d7a28d7958926d2457d05a178ecd
   repo: https://go.googlesource.com/net
   subpackages:
   - http2

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,7 +23,6 @@ import:
   - proto
 - package: github.com/kardianos/osext
 - package: github.com/mdlayher/aoe
-- package: github.com/mdlayher/bpftest
 - package: github.com/mdlayher/ethernet
 - package: github.com/mdlayher/raw
 - package: github.com/olekukonko/tablewriter


### PR DESCRIPTION
Got my changes merged into `x/net/bpf`!