### PR TITLE
Fix CLI Tables. Fixes #283

### DIFF
--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -126,13 +126,10 @@ quay.io/coreos/torus
 
 Should show your data nodes and their reporting status. Eg:
 ```
-+------------------------+--------------------------------------+---------+------+--------+---------------+--------------+
-|        ADDRESS         |                 UUID                 |  SIZE   | USED | MEMBER |    UPDATED    | REB/REP DATA |
-+------------------------+--------------------------------------+---------+------+--------+---------------+--------------+
-| http://127.0.0.1:40002 | b529f87e-2370-11e6-97ca-5ce0c5527cf4 | 5.0 GiB | 0 B  | Avail  | 2 seconds ago | 0 B/sec      |
-| http://127.0.0.1:40001 | b52a8e4c-2370-11e6-8b0a-5ce0c5527cf4 | 5.0 GiB | 0 B  | Avail  | 2 seconds ago | 0 B/sec      |
-| http://127.0.0.1:40000 | b52b8cf6-2370-11e6-8e88-5ce0c5527cf4 | 5.0 GiB | 0 B  | Avail  | 2 seconds ago | 0 B/sec      |
-+------------------------+--------------------------------------+---------+------+--------+---------------+--------------+
+ADDRESS                 UUID                                  SIZE     USED  MEMBER  UPDATED       REB/REP DATA
+http://127.0.0.1:40000  b2a2cbe6-38b7-11e6-ab37-5ce0c5527cf4  5.0 GiB  0 B   OK      1 second ago  0 B/sec
+http://127.0.0.1:40002  b2a2cbf8-38b7-11e6-9404-5ce0c5527cf4  5.0 GiB  0 B   OK      1 second ago  0 B/sec
+http://127.0.0.1:40001  b2a2cc9e-38b7-11e6-b607-5ce0c5527cf4  5.0 GiB  0 B   OK      1 second ago  0 B/sec
 Balanced: true Usage:  0.00%
 ```
 ### 5) Activate storage on the peers

--- a/Documentation/snapshotting.md
+++ b/Documentation/snapshotting.md
@@ -19,12 +19,9 @@ torusctl block snapshot list myVolume
 Which will return something like:
 ```
 Volume: myVolume
-+---------------+---------------------------+
-| SNAPSHOT NAME |         TIMESTAMP         |
-+---------------+---------------------------+
-| bar           | 2016-06-15T16:31:58-07:00 |
-| foo           | 2016-06-15T16:31:56-07:00 |
-+---------------+---------------------------+
+SNAPSHOT NAME  TIMESTAMP
+bar            2016-06-22T13:31:06-07:00
+foo            2016-06-22T13:31:04-07:00
 ```
 
 ## Delete a snapshot

--- a/cmd/torusctl/block_snapshot.go
+++ b/cmd/torusctl/block_snapshot.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/coreos/torus/block"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
@@ -81,13 +80,8 @@ func bsnapListAction(cmd *cobra.Command, args []string) {
 	if err != nil {
 		die("couldn't get snapshots for block volume %s: %v", vol, err)
 	}
-	table := tablewriter.NewWriter(os.Stdout)
-	if outputAsCSV {
-		table.SetBorder(false)
-		table.SetColumnSeparator(",")
-	} else {
-		table.SetHeader([]string{"Snapshot Name", "Timestamp"})
-	}
+	table := NewTableWriter(os.Stdout)
+	table.SetHeader([]string{"Snapshot Name", "Timestamp"})
 	for _, x := range snaps {
 		table.Append([]string{
 			x.Name,
@@ -96,8 +90,10 @@ func bsnapListAction(cmd *cobra.Command, args []string) {
 	}
 	if !outputAsCSV {
 		fmt.Printf("Volume: %s\n", vol)
+		table.Render()
+	} else {
+		table.RenderCSV()
 	}
-	table.Render()
 }
 
 func bsnapCreateAction(cmd *cobra.Command, args []string) {

--- a/cmd/torusctl/list-peers.go
+++ b/cmd/torusctl/list-peers.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
@@ -40,13 +39,8 @@ func listPeersAction(cmd *cobra.Command, args []string) {
 		die("couldn't get ring: %v", err)
 	}
 	members := ring.Members()
-	table := tablewriter.NewWriter(os.Stdout)
-	if outputAsCSV {
-		table.SetBorder(false)
-		table.SetColumnSeparator(",")
-	} else {
-		table.SetHeader([]string{"Address", "UUID", "Size", "Used", "Member", "Updated", "Reb/Rep Data"})
-	}
+	table := NewTableWriter(os.Stdout)
+	table.SetHeader([]string{"Address", "UUID", "Size", "Used", "Member", "Updated", "Reb/Rep Data"})
 	rebalancing := false
 	for _, x := range peers {
 		ringStatus := "Avail"
@@ -94,6 +88,10 @@ func listPeersAction(cmd *cobra.Command, args []string) {
 			"",
 		})
 	}
-	table.Render()
-	fmt.Printf("Balanced: %v Usage: %5.2f%%\n", !rebalancing, (float64(usedStorage) / float64(totalStorage) * 100.0))
+	if outputAsCSV {
+		table.RenderCSV()
+	} else {
+		table.Render()
+		fmt.Printf("Balanced: %v Usage: %5.2f%%\n", !rebalancing, (float64(usedStorage) / float64(totalStorage) * 100.0))
+	}
 }

--- a/cmd/torusctl/table.go
+++ b/cmd/torusctl/table.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/csv"
+	"io"
+	"strings"
+	"text/tabwriter"
+)
+
+type TableWriter struct {
+	output io.Writer
+	rows   [][]string
+	header []string
+}
+
+func NewTableWriter(output io.Writer) *TableWriter {
+	return &TableWriter{
+		output: output,
+	}
+}
+
+func (t *TableWriter) Render() {
+	tw := tabwriter.NewWriter(t.output, 5, 1, 2, ' ', 0)
+	capsHeader := make([]string, len(t.header))
+	for i, x := range t.header {
+		capsHeader[i] = strings.ToUpper(x)
+	}
+	tw.Write([]byte(strings.Join(capsHeader, "\t") + "\n"))
+	for _, x := range t.rows {
+		tw.Write([]byte(strings.Join(x, "\t") + "\n"))
+	}
+	tw.Flush()
+}
+
+func (t *TableWriter) RenderCSV() {
+	cw := csv.NewWriter(t.output)
+	cw.WriteAll(t.rows)
+	cw.Flush()
+}
+
+func (t *TableWriter) Append(s []string) {
+	t.rows = append(t.rows, s)
+}
+
+func (t *TableWriter) SetHeader(s []string) {
+	t.header = s
+}
+
+// TODO(barakmich) TableWriter.SortBy?

--- a/cmd/torusctl/volume.go
+++ b/cmd/torusctl/volume.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/coreos/torus/block"
 	"github.com/dustin/go-humanize"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
@@ -56,19 +55,18 @@ func volumeListAction(cmd *cobra.Command, args []string) {
 	if err != nil {
 		die("error listing volumes: %v\n", err)
 	}
-	table := tablewriter.NewWriter(os.Stdout)
-	if outputAsCSV {
-		table.SetBorder(false)
-		table.SetColumnSeparator(",")
-	} else {
-		table.SetHeader([]string{"Volume Name", "Size", "Type"})
-	}
+	table := NewTableWriter(os.Stdout)
+	table.SetHeader([]string{"Volume Name", "Size", "Type"})
 	for _, x := range vols {
 		table.Append([]string{
 			x.Name,
 			humanize.IBytes(x.MaxBytes),
 			x.Type,
 		})
+	}
+	if outputAsCSV {
+		table.RenderCSV()
+		return
 	}
 	table.Render()
 }

--- a/glide.lock
+++ b/glide.lock
@@ -70,8 +70,6 @@ imports:
   version: 28018267bba4d651e8e0fcbca8aae7c13f4ce4ae
 - name: github.com/mdlayher/raw
   version: b730b008e228b7a17bead43ec95edff75c2b082a
-- name: github.com/olekukonko/tablewriter
-  version: 8d0265a48283795806b872b4728c67bf5c777f20
 - name: github.com/pborman/uuid
   version: c55201b036063326c5b1b89ccfe45a184973d073
 - name: github.com/prometheus/client_golang

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,7 +25,6 @@ import:
 - package: github.com/mdlayher/aoe
 - package: github.com/mdlayher/ethernet
 - package: github.com/mdlayher/raw
-- package: github.com/olekukonko/tablewriter
 - package: github.com/pborman/uuid
 - package: github.com/prometheus/client_golang
   subpackages:


### PR DESCRIPTION
Now more consistent:
```
ADDRESS                 UUID                                  SIZE     USED  MEMBER  UPDATED       REB/REP DATA
http://127.0.0.1:40000  b2a2cbe6-38b7-11e6-ab37-5ce0c5527cf4  5.0 GiB  0 B   OK      1 second ago  0 B/sec
http://127.0.0.1:40002  b2a2cbf8-38b7-11e6-9404-5ce0c5527cf4  5.0 GiB  0 B   OK      1 second ago  0 B/sec
http://127.0.0.1:40001  b2a2cc9e-38b7-11e6-b607-5ce0c5527cf4  5.0 GiB  0 B   OK      1 second ago  0 B/sec
```

/cc @robszumski 