### PR TITLE
*: Add TCMU support to Torus

### DIFF
--- a/cmd/torusblk/tcmu.go
+++ b/cmd/torusblk/tcmu.go
@@ -1,0 +1,67 @@
+// +build linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/coreos/torus"
+	"github.com/coreos/torus/block"
+	"github.com/coreos/torus/internal/tcmu"
+	"github.com/spf13/cobra"
+)
+
+var (
+	tcmuCommand = &cobra.Command{
+		Use:   "tcmu VOLUME",
+		Short: "attach a torus block volume via SCSI",
+		Run:   tcmuAction,
+	}
+)
+
+func init() {
+	rootCommand.AddCommand(tcmuCommand)
+}
+
+func tcmuAction(cmd *cobra.Command, args []string) {
+	if len(args) != 1 {
+		cmd.Usage()
+		os.Exit(1)
+	}
+
+	srv := createServer()
+
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, os.Interrupt)
+
+	closer := make(chan bool)
+	go func() {
+		for _ = range signalChan {
+			fmt.Println("\nReceived an interrupt, disconnecting...")
+			close(closer)
+		}
+	}()
+	defer srv.Close()
+	blockvol, err := block.OpenBlockVolume(srv, args[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "server doesn't support block volumes: %s\n", err)
+		os.Exit(1)
+	}
+
+	f, err := blockvol.OpenBlockFile()
+	if err != nil {
+		if err == torus.ErrLocked {
+			fmt.Fprintf(os.Stderr, "volume %s is already mounted on another host\n", args[0])
+		} else {
+			fmt.Fprintf(os.Stderr, "can't open block volume: %s\n", err)
+		}
+		os.Exit(1)
+	}
+	defer f.Close()
+	err = torustcmu.ConnectAndServe(f, args[0], closer)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+	}
+}

--- a/cmd/torusblk/tcmu.go
+++ b/cmd/torusblk/tcmu.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/coreos/torus"
 	"github.com/coreos/torus/block"
-	"github.com/coreos/torus/internal/tcmu"
 	"github.com/spf13/cobra"
+
+	"github.com/coreos/torus/internal/tcmu"
 )
 
 var (
@@ -38,7 +39,7 @@ func tcmuAction(cmd *cobra.Command, args []string) {
 
 	closer := make(chan bool)
 	go func() {
-		for _ = range signalChan {
+		for range signalChan {
 			fmt.Println("\nReceived an interrupt, disconnecting...")
 			close(closer)
 		}
@@ -62,6 +63,6 @@ func tcmuAction(cmd *cobra.Command, args []string) {
 	defer f.Close()
 	err = torustcmu.ConnectAndServe(f, args[0], closer)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
+		fmt.Fprintf(os.Stderr, "failed to serve volume using SCSI: %s\n", err)
 	}
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 67b55b4123ce4fa39a1e88facd8b5b375ad1b0ad024a08d67549b2c818464ede
-updated: 2016-07-13T17:04:27.159050594-07:00
+hash: fa517585ba8b08cdb1ef58cd1c72dcb94ad5c4c2677967fafb2d6b624d09b8c2
+updated: 2016-07-27T16:58:59.868768007-07:00
 imports:
 - name: github.com/barakmich/mmap-go
   version: c4bd255520e591ff7549ab916c59206da5735e56
@@ -24,6 +24,10 @@ imports:
   - dbus
   - unit
   - journal
+- name: github.com/coreos/go-tcmu
+  version: 923e3cfd67c68888f5df027c06049de143c9f0d7
+  subpackages:
+  - scsi
 - name: github.com/coreos/pkg
   version: 7f080b6c11ac2d2347c3cd7521e810207ea1a041
   subpackages:
@@ -82,6 +86,7 @@ imports:
   version: a3a8fe85f2579bcfec713dbfacbdd0797a792f3a
   subpackages:
   - expfmt
+  - log
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
@@ -90,6 +95,8 @@ imports:
   version: db18267a1ca5d1d4c9a91c23d585b1ce8e255e45
 - name: github.com/serialx/hashring
   version: 75d57fa264ad17fd929304dfdb02c8e278c5c01c
+- name: github.com/Sirupsen/logrus
+  version: a283a10442df8dc09befd873fab202bf8a253d6a
 - name: github.com/spf13/cobra
   version: f368244301305f414206f889b1735a54cfc8bde8
 - name: github.com/spf13/pflag
@@ -99,7 +106,7 @@ imports:
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
-  version: a728288923b47049b2ce791836767ffbe964a5bd
+  version: 6a513affb38dc9788b449d59ffed099b8de18fa0
   repo: https://go.googlesource.com/net
   subpackages:
   - http2
@@ -109,6 +116,10 @@ imports:
   - trace
   - http2/hpack
   - internal/timeseries
+- name: golang.org/x/sys
+  version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
+  subpackages:
+  - unix
 - name: golang.org/x/time
   version: a4bde12657593d5e90d0533a3e4fd95e635124cb
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 1a8f9ce91ec93454e953a2db2357e97d299dd42aae5c93d6a68ed34a1297545a
-updated: 2016-06-09T12:14:57.730504027-04:00
+hash: 67b55b4123ce4fa39a1e88facd8b5b375ad1b0ad024a08d67549b2c818464ede
+updated: 2016-07-13T17:04:27.159050594-07:00
 imports:
 - name: github.com/barakmich/mmap-go
   version: c4bd255520e591ff7549ab916c59206da5735e56
@@ -13,8 +13,8 @@ imports:
   version: d8f325dabf429c449e0beb8cde843d4a8f53211d
   subpackages:
   - clientv3
-  - auth/authpb
   - etcdserver/api/v3rpc/rpctypes
+  - auth/authpb
   - etcdserver/etcdserverpb
   - mvcc/mvccpb
   - pkg/tlsutil
@@ -58,8 +58,6 @@ imports:
   version: 29ae4ffbc9a6fe9fb2bc5029050ce6996ea1d3bc
 - name: github.com/manucorporat/sse
   version: ee05b128a739a0fb76c7ebd3ae4810c1de808d6d
-- name: github.com/mattn/go-runewidth
-  version: d6bea18f789704b5f83375793155289da36a3c7f
 - name: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
@@ -101,7 +99,7 @@ imports:
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
-  version: 1961d9def2b2d7a28d7958926d2457d05a178ecd
+  version: a728288923b47049b2ce791836767ffbe964a5bd
   repo: https://go.googlesource.com/net
   subpackages:
   - http2

--- a/glide.yaml
+++ b/glide.yaml
@@ -32,6 +32,8 @@ import:
 - package: github.com/serialx/hashring
 - package: github.com/spf13/cobra
 - package: golang.org/x/net
+  version: master
+  repo: https://go.googlesource.com/net
   subpackages:
   - http2
   - lex/httplex
@@ -40,6 +42,5 @@ import:
   - trace
   - http2/hpack
   - internal/timeseries
-  repo: https://go.googlesource.com/net
-  version: master
 - package: google.golang.org/grpc
+- package: github.com/coreos/go-tcmu

--- a/internal/tcmu/commands.go
+++ b/internal/tcmu/commands.go
@@ -1,0 +1,36 @@
+package torustcmu
+
+import (
+	"github.com/coreos/go-tcmu"
+)
+
+func (h *torusHandler) handleSyncCommand(cmd *tcmu.SCSICmd) (tcmu.SCSIResponse, error) {
+	clog.Debugf("syncing")
+	err := h.file.Sync()
+	if err != nil {
+		clog.Errorf("sync failed: %v", err.Error())
+		return cmd.MediumError(), nil
+	}
+	return cmd.Ok(), nil
+}
+
+func (h *torusHandler) handleReportDeviceID(cmd *tcmu.SCSICmd) (tcmu.SCSIResponse, error) {
+	v := h.name
+	if len(h.name) > 240 {
+		v = v[:240]
+	}
+	data := make([]byte, 4+len(v)+6)
+	data[3] = byte(len(v) + 6)
+	copy(data[4:], []byte("torus:"))
+	copy(data[10:], []byte(v))
+	n, err := cmd.Write(data)
+	if err != nil {
+		clog.Errorf("reportDeviceID failed: %v", err)
+		return cmd.MediumError(), nil
+	}
+	if n < len(data) {
+		clog.Error("reportDeviceID failed: unable to copy enough data")
+		return cmd.MediumError(), nil
+	}
+	return cmd.Ok(), nil
+}

--- a/internal/tcmu/commands.go
+++ b/internal/tcmu/commands.go
@@ -2,6 +2,7 @@ package torustcmu
 
 import (
 	"github.com/coreos/go-tcmu"
+	"github.com/coreos/go-tcmu/scsi"
 )
 
 func (h *torusHandler) handleSyncCommand(cmd *tcmu.SCSICmd) (tcmu.SCSIResponse, error) {
@@ -31,6 +32,48 @@ func (h *torusHandler) handleReportDeviceID(cmd *tcmu.SCSICmd) (tcmu.SCSIRespons
 	if n < len(data) {
 		clog.Error("reportDeviceID failed: unable to copy enough data")
 		return cmd.MediumError(), nil
+	}
+	return cmd.Ok(), nil
+}
+
+func (h *torusHandler) handleWrite(cmd *tcmu.SCSICmd) (tcmu.SCSIResponse, error) {
+	offset := cmd.LBA() * uint64(cmd.Device().Sizes().BlockSize)
+	length := int(cmd.XferLen() * uint32(cmd.Device().Sizes().BlockSize))
+	if cmd.Buf == nil {
+		cmd.Buf = make([]byte, length)
+	}
+	if len(cmd.Buf) < int(length) {
+		//realloc
+		cmd.Buf = make([]byte, length)
+	}
+	n, err := cmd.Read(cmd.Buf[:int(length)])
+	if n < length {
+		clog.Error("write/read failed: unable to copy enough")
+		return cmd.MediumError(), nil
+	}
+	if err != nil {
+		clog.Errorf("write/read failed: error: %v", err)
+		return cmd.MediumError(), nil
+	}
+	n, err = h.file.WriteAt(cmd.Buf[:length], int64(offset))
+	if n < length {
+		clog.Error("write/write failed: unable to copy enough")
+		return cmd.MediumError(), nil
+	}
+	if err != nil {
+		clog.Errorf("write/write failed: error: %v", err)
+		return cmd.MediumError(), nil
+	}
+	if cmd.Command() != scsi.Write6 {
+		cdbinfo := cmd.GetCDB(1)
+		if cdbinfo&0xc != 0 {
+			// FUA is set
+			err := h.file.Sync()
+			if err != nil {
+				clog.Errorf("sync failed: %v", err)
+				return cmd.MediumError(), nil
+			}
+		}
 	}
 	return cmd.Ok(), nil
 }

--- a/internal/tcmu/connect.go
+++ b/internal/tcmu/connect.go
@@ -9,7 +9,10 @@ import (
 	"github.com/coreos/torus/block"
 )
 
-const defaultBlockSize = 4 * 1024
+const (
+	defaultBlockSize = 4 * 1024
+	devPath          = "/dev/torus"
+)
 
 var clog = capnslog.NewPackageLogger("github.com/coreos/torus", "tcmu")
 
@@ -40,12 +43,12 @@ func ConnectAndServe(f *block.BlockFile, name string, closer chan bool) error {
 				},
 			}, 1),
 	}
-	d, err := tcmu.OpenTCMUDevice("/dev/torus", h)
+	d, err := tcmu.OpenTCMUDevice(devPath, h)
 	if err != nil {
 		return err
 	}
 	defer d.Close()
-	fmt.Printf("go-tcmu attached to %s/%s\n", "/dev/torus", name)
+	fmt.Printf("go-tcmu attached to %s/%s\n", devPath, name)
 	<-closer
 	return nil
 }

--- a/internal/tcmu/connect.go
+++ b/internal/tcmu/connect.go
@@ -71,7 +71,7 @@ func (h *torusHandler) HandleCommand(cmd *tcmu.SCSICmd) (tcmu.SCSIResponse, erro
 	case scsi.Read6, scsi.Read10, scsi.Read12, scsi.Read16:
 		return tcmu.EmulateRead(cmd, h.file)
 	case scsi.Write6, scsi.Write10, scsi.Write12, scsi.Write16:
-		return tcmu.EmulateWrite(cmd, h.file)
+		return h.handleWrite(cmd)
 	case scsi.SynchronizeCache, scsi.SynchronizeCache16:
 		return h.handleSyncCommand(cmd)
 	case scsi.MaintenanceIn:


### PR DESCRIPTION
This adds `torusblk tcmu [VOLNAME]` which uses the TCM in Userspace module (and the sister library, https://github.com/coreos/go-tcmu) to talk to the Linux kernel SCSI stack.

This requires a recent-ish kernel -- 4.2 or greater, and 4.6 for better performance -- but is far more stable and generally faster than the equivalent NBD connection.

Followup, add documentation surrounding this.