### PR TITLE
Support generating bash completion shells

### DIFF
--- a/cmd/torusblk/completion.go
+++ b/cmd/torusblk/completion.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCommand = &cobra.Command{
+	Use:   "completion",
+	Short: "Output bash completion code",
+	Run:   completionAction,
+}
+
+func completionAction(cmd *cobra.Command, args []string) {
+	cmd.Root().GenBashCompletion(os.Stdout)
+}

--- a/cmd/torusblk/main.go
+++ b/cmd/torusblk/main.go
@@ -48,6 +48,7 @@ var versionCommand = &cobra.Command{
 func init() {
 	rootCommand.AddCommand(aoeCommand)
 	rootCommand.AddCommand(versionCommand)
+	rootCommand.AddCommand(completionCommand)
 
 	// Flexvolume commands
 	rootCommand.AddCommand(initCommand)

--- a/cmd/torusctl/completion.go
+++ b/cmd/torusctl/completion.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCommand = &cobra.Command{
+	Use:   "completion",
+	Short: "Output bash completion code",
+	Run:   completionAction,
+}
+
+func completionAction(cmd *cobra.Command, args []string) {
+	cmd.Root().GenBashCompletion(os.Stdout)
+}

--- a/cmd/torusctl/torusctl.go
+++ b/cmd/torusctl/torusctl.go
@@ -45,6 +45,7 @@ func init() {
 	rootCommand.AddCommand(versionCommand)
 	rootCommand.AddCommand(wipeCommand)
 	rootCommand.AddCommand(configCommand)
+	rootCommand.AddCommand(completionCommand)
 	flagconfig.AddConfigFlags(rootCommand.PersistentFlags())
 }
 

--- a/cmd/torusd/main.go
+++ b/cmd/torusd/main.go
@@ -43,8 +43,9 @@ var (
 	logpkg      string
 	cfg         torus.Config
 
-	debug   bool
-	version bool
+	debug      bool
+	version    bool
+	completion bool
 )
 
 var rootCommand = &cobra.Command{
@@ -66,6 +67,7 @@ func init() {
 	rootCommand.PersistentFlags().StringVarP(&logpkg, "logpkg", "", "", "Specific package logging")
 	rootCommand.PersistentFlags().BoolVarP(&autojoin, "auto-join", "", false, "Automatically join the storage pool")
 	rootCommand.PersistentFlags().BoolVarP(&version, "version", "", false, "Print version info and exit")
+	rootCommand.PersistentFlags().BoolVarP(&completion, "completion", "", false, "Output bash completion code")
 	flagconfig.AddConfigFlags(rootCommand.PersistentFlags())
 }
 
@@ -137,6 +139,10 @@ func parsePercentage(percentString string) (uint64, error) {
 }
 
 func runServer(cmd *cobra.Command, args []string) {
+	if completion {
+		cmd.Root().GenBashCompletion(os.Stdout)
+		os.Exit(0)
+	}
 
 	var (
 		srv *torus.Server


### PR DESCRIPTION
* This patch includes `completion` sub-command for `torusctl` and `torusblk` and `completion`option for `torusd` to generate bash completion shells.