### PR TITLE
GobalMetadata doesn't return error

### DIFF
--- a/block/volume.go
+++ b/block/volume.go
@@ -75,10 +75,7 @@ func (s *BlockVolume) getOrCreateBlockINode(ref torus.INodeRef) (*models.INode, 
 	if ref.INode != 1 {
 		return s.srv.INodes.GetINode(s.getContext(), ref)
 	}
-	globals, err := s.mds.GlobalMetadata()
-	if err != nil {
-
-	}
+	globals := s.mds.GlobalMetadata()
 	bs, err := blockset.CreateBlocksetFromSpec(globals.DefaultBlockSpec, nil)
 	if err != nil {
 		return nil, err

--- a/cmd/torusblk/nbd.go
+++ b/cmd/torusblk/nbd.go
@@ -97,18 +97,16 @@ func connectNBD(srv *torus.Server, f *block.BlockFile, target string, closer cha
 	defer f.Close()
 	size := f.Size()
 
-	gmd, err := srv.MDS.GlobalMetadata()
-	if err != nil {
-		return err
-	}
+	gmd := srv.MDS.GlobalMetadata()
 
 	handle := nbd.Create(f, int64(size), int64(gmd.BlockSize))
 
 	if target == "" {
-		target, err = nbd.FindDevice()
+		t, err := nbd.FindDevice()
 		if err != nil {
 			return err
 		}
+		target = t
 	}
 
 	dev, err := handle.OpenDevice(target)

--- a/cmd/torusctl/list-peers.go
+++ b/cmd/torusctl/list-peers.go
@@ -26,10 +26,7 @@ func listPeersAction(cmd *cobra.Command, args []string) {
 	var usedStorage uint64
 
 	mds := mustConnectToMDS()
-	gmd, err := mds.GlobalMetadata()
-	if err != nil {
-		die("couldn't get global metadata: %v", err)
-	}
+	gmd := mds.GlobalMetadata()
 	peers, err := mds.GetPeers()
 	if err != nil {
 		die("couldn't get peers: %v", err)

--- a/distributor/client.go
+++ b/distributor/client.go
@@ -76,11 +76,7 @@ func (d *distClient) getConn(uuid string) protocols.RPC {
 		clog.Errorf("couldn't parse address: %s", pi.Address)
 		return nil
 	}
-	gmd, err := d.dist.srv.MDS.GlobalMetadata()
-	if err != nil {
-		clog.Errorf("couldn't get GMD: %s", err)
-		return nil
-	}
+	gmd := d.dist.srv.MDS.GlobalMetadata()
 	conn, err := protocols.DialRPC(uri, connectTimeout, gmd)
 	d.mut.Lock()
 	defer d.mut.Unlock()

--- a/distributor/distributor.go
+++ b/distributor/distributor.go
@@ -40,10 +40,7 @@ func newDistributor(srv *torus.Server, addr *url.URL) (*Distributor, error) {
 		blocks: srv.Blocks,
 		srv:    srv,
 	}
-	gmd, err := d.srv.MDS.GlobalMetadata()
-	if err != nil {
-		return nil, err
-	}
+	gmd := d.srv.MDS.GlobalMetadata()
 	if addr != nil {
 		d.rpcSrv, err = protocols.ListenRPC(addr, d, gmd)
 		if err != nil {

--- a/distributor/distributor_test.go
+++ b/distributor/distributor_test.go
@@ -17,7 +17,7 @@ func newServer(md *temp.Server) *torus.Server {
 		StorageSize: 100 * 1024 * 1024,
 	}
 	mds := temp.NewClient(cfg, md)
-	gmd, _ := mds.GlobalMetadata()
+	gmd := mds.GlobalMetadata()
 	blocks, _ := torus.CreateBlockStore("temp", "current", cfg, gmd)
 	s, _ := torus.NewServerByImpl(cfg, mds, blocks)
 	return s

--- a/file.go
+++ b/file.go
@@ -87,10 +87,7 @@ func (f *File) Replaces() uint64 {
 }
 
 func (s *Server) CreateFile(volume *models.Volume, inode *models.INode, blocks Blockset) (*File, error) {
-	md, err := s.MDS.GlobalMetadata()
-	if err != nil {
-		return nil, err
-	}
+	md := s.MDS.GlobalMetadata()
 	clog.Tracef("Creating File For Inode %d:%d", inode.Volume, inode.INode)
 	return &File{
 		volume:  volume,

--- a/file_blackbox_test.go
+++ b/file_blackbox_test.go
@@ -31,10 +31,7 @@ func makeFile(name string, t *testing.T) (*torus.Server, *torus.File) {
 		Id:   3,
 		Type: "test",
 	}
-	globals, err := srv.MDS.GlobalMetadata()
-	if err != nil {
-		t.Fatal(err)
-	}
+	globals := srv.MDS.GlobalMetadata()
 	bs, err := blockset.CreateBlocksetFromSpec(globals.DefaultBlockSpec, srv.Blocks)
 	if err != nil {
 		t.Fatal(err)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -35,7 +35,7 @@ func newServer(t testing.TB, md *temp.Server) *torus.Server {
 		DataDir:     dir,
 	}
 	mds := temp.NewClient(cfg, md)
-	gmd, _ := mds.GlobalMetadata()
+	gmd := mds.GlobalMetadata()
 	blocks, err := torus.CreateBlockStore("mfile", "current", cfg, gmd)
 	if err != nil {
 		t.Fatal(err)

--- a/local_server.go
+++ b/local_server.go
@@ -37,10 +37,7 @@ func NewServer(cfg Config, metadataServiceKind, blockStoreKind string) (*Server,
 		return nil, err
 	}
 
-	global, err := mds.GlobalMetadata()
-	if err != nil {
-		return nil, err
-	}
+	global := mds.GlobalMetadata()
 
 	offset := cfg.StorageSize % global.BlockSize
 	if offset != 0 {

--- a/metadata.go
+++ b/metadata.go
@@ -27,7 +27,10 @@ type MetadataService interface {
 	NewVolumeID() (VolumeID, error)
 	Kind() MetadataKind
 
-	GlobalMetadata() (GlobalMetadata, error)
+	// GlobalMetadata backing struct must be instantiated upon the
+	// service creation. If it can not be created the MetadataService
+	// creation must fail.
+	GlobalMetadata() GlobalMetadata
 
 	// Returns a UUID based on the underlying datadir. Should be
 	// unique for every created datadir.

--- a/metadata/etcd/etcd.go
+++ b/metadata/etcd/etcd.go
@@ -172,8 +172,8 @@ func (c *etcdCtx) Close() error {
 	return c.etcd.Close()
 }
 
-func (c *etcdCtx) GlobalMetadata() (torus.GlobalMetadata, error) {
-	return c.etcd.global, nil
+func (c *etcdCtx) GlobalMetadata() torus.GlobalMetadata {
+	return c.etcd.global
 }
 
 func (c *etcdCtx) UUID() string {

--- a/metadata/temp/temp.go
+++ b/metadata/temp/temp.go
@@ -83,8 +83,8 @@ func (t *Client) Kind() torus.MetadataKind {
 	return torus.TempMetadata
 }
 
-func (t *Client) GlobalMetadata() (torus.GlobalMetadata, error) {
-	return t.srv.global, nil
+func (t *Client) GlobalMetadata() torus.GlobalMetadata {
+	return t.srv.global
 }
 
 func (t *Client) UUID() string {


### PR DESCRIPTION
All implementations of MetadataService.GlobalMetadata() never fail.
