### PR TITLE
nbd: fix Socketpair call

### DIFF
--- a/internal/nbd/nbd.go
+++ b/internal/nbd/nbd.go
@@ -157,7 +157,7 @@ func (nbd *NBD) OpenDevice(dev string) (string, error) {
 
 	// possible candidate
 	ioctl(f.Fd(), BLKROSET, 0) // I'm really sorry about this
-	pair, err := syscall.Socketpair(syscall.SOCK_STREAM, syscall.AF_UNIX, 0)
+	pair, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Domain and type were swapped. By accident they both have value 0x1 so the call still worked. See http://man7.org/linux/man-pages/man2/socket.2.html
