### PR TITLE
storage/block_device: initial implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,11 @@ REPOPATH = github.com/coreos/torus
 VERBOSE_1 := -v
 VERBOSE_2 := -v -x
 
-WHAT := torusd torusctl torusblk
+WHAT := torusd torusctl torusblk mkfs.torus fsck.torus
 
 build: vendor
 	for target in $(WHAT); do \
+		echo "building $$target..."; \
 		$(BUILD_ENV_FLAGS) go build $(VERBOSE_$(V)) -o bin/$$target -ldflags "-X $(REPOPATH).Version=$(VERSION)" ./cmd/$$target; \
 	done
 

--- a/cmd/fsck.torus/fsck.torus.go
+++ b/cmd/fsck.torus/fsck.torus.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	fsck "github.com/coreos/torus/cmd/fsck.torus/lib"
+)
+
+var (
+	verbose      bool
+	blockSizeStr string
+)
+
+func stderr(msg string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, strings.TrimSpace(msg)+"\n", args...)
+}
+
+func debug(msg string, args ...interface{}) {
+	if verbose {
+		stderr(msg, args...)
+	}
+}
+
+func die(why string, args ...interface{}) {
+	stderr(why, args...)
+	os.Exit(1)
+}
+
+func main() {
+	if err := rootCommand.Execute(); err != nil {
+		die("%v", err)
+	}
+}
+
+var rootCommand = &cobra.Command{
+	Use:   "fsck.torus device",
+	Short: "check the consistency of a block device for torus",
+	Long:  "",
+	Run:   runFunc,
+}
+
+func init() {
+	rootCommand.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable debug logging")
+	rootCommand.PersistentFlags().StringVarP(&blockSizeStr, "block-size", "b", "512K", "torus cluster block size")
+}
+
+func runFunc(cmd *cobra.Command, args []string) {
+	if len(args) != 1 {
+		cmd.Usage()
+		os.Exit(1)
+	}
+
+	torusBlockSize, err := parseBlockSize(blockSizeStr)
+	if err != nil {
+		die("error parsing block size: %v", err)
+	}
+
+	stderr("Checking the consistency of %s", args[0])
+
+	fsck.Fsck(verbose, args[0], torusBlockSize)
+}
+
+func parseBlockSize(str string) (uint64, error) {
+	str = strings.ToUpper(str)
+	multiplier := 1
+	switch {
+	case strings.HasSuffix(str, "K"):
+		multiplier = 1024
+		str = strings.TrimSuffix(str, "K")
+	case strings.HasSuffix(str, "M"):
+		multiplier = 1024 * 1024
+		str = strings.TrimSuffix(str, "M")
+	case strings.HasSuffix(str, "G"):
+		multiplier = 1024 * 1024 * 1024 // I really really hope no one uses this
+		str = strings.TrimSuffix(str, "G")
+	}
+	blockSize, err := strconv.ParseUint(str, 0, 64)
+	if err != nil {
+		return 0, err
+	}
+	return blockSize * uint64(multiplier), nil
+}

--- a/cmd/fsck.torus/lib/lib.go
+++ b/cmd/fsck.torus/lib/lib.go
@@ -1,0 +1,109 @@
+package lib
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	blockDevice "github.com/coreos/torus/storage/block_device"
+)
+
+func stderr(msg string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, strings.TrimSpace(msg)+"\n", args...)
+}
+
+func debug(verbose bool, msg string, args ...interface{}) {
+	if verbose {
+		stderr(msg, args...)
+	}
+}
+
+func Fsck(verbose bool, deviceName string, torusBlockSize uint64) error {
+	debug(verbose, "checking device %s for torus with a cluster block size of %d bytes", deviceName, torusBlockSize)
+	deviceFile, err := os.OpenFile(deviceName, os.O_RDWR, 0777|os.ModeDevice)
+	if err != nil {
+		return err
+	}
+	defer deviceFile.Close()
+
+	deviceSize, err := blockDevice.GetDeviceSize(deviceFile)
+	if err != nil {
+		return err
+	}
+
+	debug(verbose, "this device has a size of %d", deviceSize)
+
+	buf := make([]byte, blockDevice.BlockSize)
+	_, err = deviceFile.Read(buf)
+	if err != nil {
+		return err
+	}
+	metadata := blockDevice.Metadata{}
+	err = metadata.Unmarshal(buf)
+	if err != nil {
+		return err
+	}
+	if metadata.TorusBlockSize != torusBlockSize {
+		return fmt.Errorf("device has a torus block size of %d, whereas we're checking for %d", metadata.TorusBlockSize, torusBlockSize)
+	}
+	debug(verbose, "torus was formatted on %s", metadata.FormattedTimestamp.String())
+	stderr("there should be %d blocks in use", metadata.UsedBlocks)
+
+	jumpSize := blockDevice.BlockSize + torusBlockSize
+	currOffset := blockDevice.MetadataSize
+	index := 0
+	var usedBlocks uint64 = 0
+	for {
+		index++
+		if currOffset >= deviceSize {
+			// we've reached the end of the device
+			break
+		}
+
+		_, err = deviceFile.Seek(int64(currOffset), os.SEEK_SET)
+		if err != nil {
+			return err
+		}
+
+		n, err := deviceFile.Read(buf)
+		if err != nil {
+			return err
+		}
+		if uint64(n) != blockDevice.BlockSize {
+			return fmt.Errorf("Read an unexpected number of bytes? %d", n)
+		}
+
+		hdrs := blockDevice.NewBlockHeaders()
+		err = hdrs.Unmarshal(buf)
+		if err != nil {
+			return err
+		}
+		for _, h := range hdrs {
+			if h.Location >= deviceSize {
+				stderr("Found a block header claiming that block %d,%d,%d is at location %d, which is off the disk!", h.Volume, h.Inode, h.Index, h.Location)
+				stderr("Printing all of the headers for this block:")
+				for _, h := range hdrs {
+					fmt.Printf(" - volume:   %d\n", h.Volume)
+					fmt.Printf(" - inode:    %d\n", h.Inode)
+					fmt.Printf(" - index:    %d\n", h.Index)
+					fmt.Printf(" - location: %d\n", h.Location)
+					fmt.Printf("------------\n")
+				}
+				stderr("This is at block #%d, offset %d", index, currOffset)
+				return fmt.Errorf("This block got corrupted somehow")
+			}
+			if !h.IsNil() && h.Location == 0 {
+				usedBlocks++
+			}
+		}
+
+		currOffset += jumpSize
+	}
+	deviceFile.Close()
+	if usedBlocks != metadata.UsedBlocks {
+		return fmt.Errorf("there were supposed to be %d blocks in use, but I found %d in use", metadata.UsedBlocks, usedBlocks)
+	}
+	stderr("device %s passes fsck", deviceName)
+
+	return nil
+}

--- a/cmd/mkfs.torus/lib/lib.go
+++ b/cmd/mkfs.torus/lib/lib.go
@@ -1,0 +1,106 @@
+package lib
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+
+	blockDevice "github.com/coreos/torus/storage/block_device"
+)
+
+const (
+	DefaultBlockSize = 1024 * 512
+)
+
+func debug(verbose bool, msg string, args ...interface{}) {
+	if verbose {
+		fmt.Fprintf(os.Stderr, strings.TrimSpace(msg)+"\n", args...)
+	}
+}
+
+func Mkfs(torusBlockSize uint64, verbose bool, deviceName string) error {
+	debug(verbose, "formatting device %s for torus with a cluster block size of %d bytes", deviceName, torusBlockSize)
+	deviceFile, err := os.OpenFile(deviceName, os.O_RDWR, 0777|os.ModeDevice)
+	if err != nil {
+		return err
+	}
+
+	deviceSize, err := blockDevice.GetDeviceSize(deviceFile)
+	if err != nil {
+		return err
+	}
+
+	debug(verbose, "this device has a size of %d", deviceSize)
+
+	zeros := make([]byte, blockDevice.BlockSize)
+
+	jumpSize := blockDevice.BlockSize + torusBlockSize
+	currOffset := blockDevice.MetadataSize
+	for {
+		if currOffset >= deviceSize {
+			// we've reached the end of the device
+			break
+		}
+		if verbose {
+			currentBlock := (currOffset - blockDevice.MetadataSize) / jumpSize
+			totalBlocks := (deviceSize - blockDevice.MetadataSize) / jumpSize
+			if currOffset == blockDevice.MetadataSize {
+				fmt.Fprintf(os.Stderr, "\n")
+			}
+			fmt.Fprintf(os.Stderr, "\rzero'ing out block headers: %d/%d", currentBlock, totalBlocks)
+		}
+
+		_, err = deviceFile.Seek(int64(currOffset), os.SEEK_SET)
+		if err != nil {
+			return err
+		}
+
+		n, err := deviceFile.Write(zeros)
+		if err != nil {
+			return err
+		}
+		if uint64(n) != blockDevice.BlockSize {
+			return fmt.Errorf("Wrote an unexpected number of bytes? %d", n)
+		}
+
+		syscall.Sync()
+
+		currOffset += jumpSize
+	}
+	if verbose {
+		fmt.Fprintf(os.Stderr, "\n")
+	}
+
+	debug(verbose, "block headers successfully zero'd, writing metadata...")
+
+	metadata := &blockDevice.Metadata{
+		TorusBlockSize:     torusBlockSize,
+		FormattedTimestamp: time.Now(),
+		UsedBlocks:         0,
+	}
+
+	metadataBytes := metadata.Marshal()
+
+	_, err = deviceFile.Seek(0, os.SEEK_SET)
+	if err != nil {
+		return err
+	}
+
+	n, err := deviceFile.Write(metadataBytes)
+	if err != nil {
+		return err
+	}
+	if n != len(metadataBytes) {
+		return fmt.Errorf("Wrote an unexpected number of bytes? %d", n)
+	}
+
+	debug(verbose, "metadata written, syncing changes to disk...")
+
+	deviceFile.Close()
+	syscall.Sync()
+	debug(verbose, "device %s formatted successfully", deviceName)
+
+	return nil
+}

--- a/cmd/mkfs.torus/mkfs.torus.go
+++ b/cmd/mkfs.torus/mkfs.torus.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/coreos/torus/cmd/mkfs.torus/lib"
+)
+
+var (
+	verbose      bool
+	assumeYes    bool
+	blockSizeStr string
+)
+
+func stderr(msg string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, strings.TrimSpace(msg)+"\n", args...)
+}
+
+func debug(msg string, args ...interface{}) {
+	if verbose {
+		stderr(msg, args...)
+	}
+}
+
+func die(why string, args ...interface{}) {
+	stderr(why, args...)
+	os.Exit(1)
+}
+
+func main() {
+	if err := rootCommand.Execute(); err != nil {
+		die("%v", err)
+	}
+}
+
+var rootCommand = &cobra.Command{
+	Use:   "mkfs.torus device",
+	Short: "format a block device for torus",
+	Long:  "",
+	Run:   runFunc,
+}
+
+func init() {
+	rootCommand.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable debug logging")
+	rootCommand.PersistentFlags().BoolVarP(&assumeYes, "yes", "y", false, "assume yes on all prompts")
+	rootCommand.PersistentFlags().StringVarP(&blockSizeStr, "block-size", "b", "512K", "torus cluster block size")
+}
+
+func runFunc(cmd *cobra.Command, args []string) {
+	if len(args) != 1 {
+		cmd.Usage()
+		os.Exit(1)
+	}
+
+	torusBlockSize, err := parseBlockSize(blockSizeStr)
+	if err != nil {
+		die("error parsing block size: %v", err)
+	}
+
+	stderr("This is going to format %s for torus.", args[0])
+	stderr("This will destroy any data on the device.")
+	if !assumeYes {
+		fmt.Fprintf(os.Stderr, "Are you SURE? [y/N] ")
+
+		var response string
+		_, err = fmt.Scanln(&response)
+		if err != nil {
+			// Not providing input can error, so not worth printing it
+			os.Exit(1)
+		}
+
+		userSaidYes := false
+
+		for _, s := range []string{"y", "yes"} {
+			userSaidYes = userSaidYes || strings.Compare(strings.ToLower(response), s) == 0
+		}
+
+		if !userSaidYes {
+			os.Exit(1)
+		}
+	}
+
+	err = lib.Mkfs(torusBlockSize, verbose, args[0])
+	if err != nil {
+		die("%v", err)
+	}
+}
+
+func parseBlockSize(str string) (uint64, error) {
+	str = strings.ToUpper(str)
+	multiplier := 1
+	switch {
+	case strings.HasSuffix(str, "K"):
+		multiplier = 1024
+		str = strings.TrimSuffix(str, "K")
+	case strings.HasSuffix(str, "M"):
+		multiplier = 1024 * 1024
+		str = strings.TrimSuffix(str, "M")
+	case strings.HasSuffix(str, "G"):
+		multiplier = 1024 * 1024 * 1024 // I really really hope no one uses this
+		str = strings.TrimSuffix(str, "G")
+	}
+	blockSize, err := strconv.ParseUint(str, 0, 64)
+	if err != nil {
+		return 0, err
+	}
+	return blockSize * uint64(multiplier), nil
+}

--- a/cmd/torusd/main.go
+++ b/cmd/torusd/main.go
@@ -32,6 +32,7 @@ import (
 
 var (
 	dataDir     string
+	blockDevice string
 	httpAddress string
 	peerAddress string
 	sizeStr     string
@@ -57,6 +58,7 @@ var rootCommand = &cobra.Command{
 }
 
 func init() {
+	rootCommand.PersistentFlags().StringVarP(&blockDevice, "block-device", "", "/dev/thing", "Path to a torus formatted block device")
 	rootCommand.PersistentFlags().StringVarP(&dataDir, "data-dir", "", "torus-data", "Path to the data directory")
 	rootCommand.PersistentFlags().BoolVarP(&debug, "debug", "", false, "Turn on debug output")
 	rootCommand.PersistentFlags().BoolVarP(&debugInit, "debug-init", "", false, "Run a default init for the MDS if one doesn't exist")
@@ -123,6 +125,7 @@ func configureServer(cmd *cobra.Command, args []string) {
 
 	cfg = flagconfig.BuildConfigFromFlags()
 	cfg.DataDir = dataDir
+	cfg.BlockDevice = blockDevice
 	cfg.StorageSize = size
 }
 
@@ -166,6 +169,8 @@ func runServer(cmd *cobra.Command, args []string) {
 			}
 		}
 		fallthrough
+	case blockDevice != "":
+		srv, err = torus.NewServer(cfg, "etcd", "block_device")
 	default:
 		srv, err = torus.NewServer(cfg, "etcd", "mfile")
 	}

--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import "crypto/tls"
 
 type Config struct {
 	DataDir         string
+	BlockDevice     string
 	StorageSize     uint64
 	MetadataAddress string
 	ReadCacheSize   uint64

--- a/storage.go
+++ b/storage.go
@@ -135,6 +135,17 @@ func BlockRefFromBytes(b []byte) BlockRef {
 	return ref
 }
 
+func BlockRefFromUint64s(volume, inode, index uint64) BlockRef {
+	ref := BlockRef{
+		INodeRef: INodeRef{
+			volume: VolumeID(volume),
+			INode:  INodeID(inode),
+		},
+		Index: IndexID(index),
+	}
+	return ref
+}
+
 func (b BlockRef) String() string {
 	return fmt.Sprintf("br %x : %x : %x", b.volume, b.INode, b.Index)
 }

--- a/storage/block_device.go
+++ b/storage/block_device.go
@@ -1,0 +1,492 @@
+package storage
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"os"
+
+	"golang.org/x/net/context"
+
+	"github.com/coreos/torus"
+	blockDevice "github.com/coreos/torus/storage/block_device"
+)
+
+func init() {
+	torus.RegisterBlockStore("block_device", newBlockDeviceBlockStore)
+}
+
+func (d *deviceBlock) readBlockHeader(offset uint64) (blockDevice.BlockHeaders, error) {
+	_, err := d.deviceFile.Seek(int64(offset), os.SEEK_SET)
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, blockDevice.BlockSize)
+	n, err := d.deviceFile.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+	if n != len(buf) {
+		return nil, fmt.Errorf("Read an unexpected number of bytes? %d", n)
+	}
+	hdrs, err := DeserializeBlockHeader(buf)
+	if err != nil {
+		return nil, err
+	}
+	return hdrs, nil
+}
+
+func SerializeBlockHeader(hdrs blockDevice.BlockHeaders) ([]byte, error) {
+	buf := make([]byte, blockDevice.BlockSize)
+	err := hdrs.Marshal(buf)
+	return buf, err
+}
+
+func DeserializeBlockHeader(buf []byte) (blockDevice.BlockHeaders, error) {
+	hdrs := blockDevice.NewBlockHeaders()
+	err := hdrs.Unmarshal(buf)
+	return hdrs, err
+}
+
+func (d *deviceBlock) writeBlockHeader(hdrs blockDevice.BlockHeaders, offset uint64) error {
+	buf, err := SerializeBlockHeader(hdrs)
+	if err != nil {
+		return err
+	}
+
+	_, err = d.deviceFile.Seek(int64(offset), os.SEEK_SET)
+	if err != nil {
+		return err
+	}
+	n, err := d.deviceFile.Write(buf)
+	if err != nil {
+		return err
+	}
+	if uint64(n) != blockDevice.BlockSize {
+		return fmt.Errorf("Wrote an unexpected number of bytes? %d", n)
+	}
+	return nil
+}
+
+type deviceBlock struct {
+	deviceFile *os.File
+
+	metadata   *blockDevice.Metadata
+	deviceSize uint64
+
+	cfg        torus.Config
+	globalMeta torus.GlobalMetadata
+}
+
+func newBlockDeviceBlockStore(name string, cfg torus.Config, meta torus.GlobalMetadata) (torus.BlockStore, error) {
+	f, err := os.OpenFile(cfg.BlockDevice, os.O_RDWR, 0777|os.ModeDevice)
+	if err != nil {
+		return nil, err
+	}
+
+	d := &deviceBlock{
+		deviceFile: f,
+		cfg:        cfg,
+		globalMeta: meta,
+	}
+
+	deviceSize, err := blockDevice.GetDeviceSize(f)
+	if err != nil {
+		return nil, err
+	}
+
+	d.deviceSize = deviceSize
+
+	mdata, err := d.readMetadata()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+
+	d.metadata = mdata
+
+	if mdata.TorusBlockSize != meta.BlockSize {
+		f.Close()
+		return nil, fmt.Errorf("device %s has been formatted with block size %d, and the cluster is using block size %d", cfg.BlockDevice, mdata.TorusBlockSize, meta.BlockSize)
+	}
+
+	return d, nil
+}
+
+func (d *deviceBlock) Kind() string {
+	return "block_device"
+}
+
+func (d *deviceBlock) Flush() error {
+	return d.deviceFile.Sync()
+}
+
+func (d *deviceBlock) Close() error {
+	return d.deviceFile.Close()
+}
+
+func (d *deviceBlock) HasBlock(ctx context.Context, b torus.BlockRef) (bool, error) {
+	_, found, err := d.findBlockOffset(b)
+	return found, err
+}
+
+func (d *deviceBlock) GetBlock(ctx context.Context, b torus.BlockRef) ([]byte, error) {
+	offset, found, err := d.findBlockOffset(b)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("block not found")
+	}
+	_, err = d.deviceFile.Seek(int64(offset+blockDevice.BlockSize), os.SEEK_SET)
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, d.metadata.TorusBlockSize)
+	n, err := d.deviceFile.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+	if uint64(n) != d.metadata.TorusBlockSize {
+		return nil, fmt.Errorf("Read an unexpected number of bytes? %d", n)
+	}
+	return buf, nil
+}
+
+func (d *deviceBlock) WriteBlock(ctx context.Context, b torus.BlockRef, data []byte) error {
+	if uint64(len(data)) != d.metadata.TorusBlockSize {
+		return fmt.Errorf("data buffer does not match block size")
+	}
+	offset, found, err := d.findBlockOffset(b)
+	if found {
+		// This block already exists! Let's overwrite the data and leave it at
+		// that.
+		err = d.writeData(offset+blockDevice.BlockSize, data)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// This block does NOT already exist. Let's create it!
+	offset, err = d.findDefaultBlockOffset(b)
+	if err != nil {
+		return err
+	}
+	hdrs, err := d.readBlockHeader(offset)
+	if err != nil {
+		return err
+	}
+	if !hdrs.IsUsed() {
+		// The default block isn't used! Let's use it!
+		err = d.writeData(offset+blockDevice.BlockSize, data)
+		if err != nil {
+			return err
+		}
+		// And update the headers to say we used it
+		err = hdrs.Add(&blockDevice.BlockHeader{
+			Volume:   uint64(b.Volume()),
+			Inode:    uint64(b.INode),
+			Index:    uint64(b.Index),
+			Location: 0,
+		})
+		if err != nil {
+			return err
+		}
+		err = d.writeBlockHeader(hdrs, offset)
+		if err != nil {
+			return err
+		}
+		// Done! Let's update the used blocks counter
+		err = d.incrementUsedBlocks()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// The default block is used. Let's find an unused block.
+	jumpSize := blockDevice.BlockSize + d.metadata.TorusBlockSize
+	currOffset := offset + jumpSize
+	for {
+		if currOffset > d.deviceSize-jumpSize {
+			currOffset = blockDevice.MetadataSize
+		}
+		if currOffset == offset {
+			// oh my, it looks like we looped all the way around the device
+			return fmt.Errorf("device is full")
+		}
+		currHdrs, err := d.readBlockHeader(currOffset)
+		if err != nil {
+			return err
+		}
+		if !currHdrs.IsUsed() {
+			// Found one!
+			err = d.writeData(currOffset+blockDevice.BlockSize, data)
+			if err != nil {
+				return err
+			}
+			// Update the default headers to point to here
+			err = hdrs.Add(&blockDevice.BlockHeader{
+				Volume:   uint64(b.Volume()),
+				Inode:    uint64(b.INode),
+				Index:    uint64(b.Index),
+				Location: currOffset,
+			})
+			if err != nil {
+				return err
+			}
+			err = d.writeBlockHeader(hdrs, offset)
+			if err != nil {
+				return err
+			}
+			// And finally update these headers to say we used this
+			err = currHdrs.Add(&blockDevice.BlockHeader{
+				Volume:   uint64(b.Volume()),
+				Inode:    uint64(b.INode),
+				Index:    uint64(b.Index),
+				Location: 0,
+			})
+			if err != nil {
+				return err
+			}
+			err = d.writeBlockHeader(currHdrs, currOffset)
+			if err != nil {
+				return err
+			}
+			// Done! Let's update the used blocks counter
+			err = d.incrementUsedBlocks()
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+		currOffset += jumpSize
+	}
+}
+
+func (d *deviceBlock) writeData(offset uint64, data []byte) error {
+	_, err := d.deviceFile.Seek(int64(offset), os.SEEK_SET)
+	if err != nil {
+		return err
+	}
+	n, err := d.deviceFile.Write(data)
+	if err != nil {
+		return err
+	}
+	if n != len(data) {
+		return fmt.Errorf("Wrote an unexpected number of bytes? %d", n)
+	}
+	return nil
+}
+
+func (d *deviceBlock) WriteBuf(ctx context.Context, b torus.BlockRef) ([]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (d *deviceBlock) DeleteBlock(ctx context.Context, b torus.BlockRef) error {
+	// Find the block
+	offset, found, err := d.findBlockOffset(b)
+	if !found {
+		return fmt.Errorf("block doesn't exist")
+	}
+	// Read its headers
+	hdrs, err := d.readBlockHeader(offset)
+	if err != nil {
+		return err
+	}
+	// Update the headers to not include this block
+	hdrs.Delete(b)
+	// Write the updated headers
+	err = d.writeBlockHeader(hdrs, offset)
+	if err != nil {
+		return err
+	}
+	// Done! Let's update the used blocks counter
+	err = d.decrementUsedBlocks()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *deviceBlock) NumBlocks() uint64 {
+	return (d.deviceSize - blockDevice.MetadataSize) / d.metadata.TorusBlockSize
+}
+
+func (d *deviceBlock) UsedBlocks() uint64 {
+	return d.metadata.UsedBlocks
+}
+
+type deviceBlockIterator struct {
+	db           *deviceBlock
+	deviceSize   uint64
+	currOffset   uint64
+	currBlockRef torus.BlockRef
+	done         bool
+	err          error
+}
+
+func (d *deviceBlock) BlockIterator() torus.BlockIterator {
+	i := &deviceBlockIterator{
+		db:           d,
+		done:         false,
+		currBlockRef: torus.BlockRefFromUint64s(0, 0, 0),
+	}
+	return i
+}
+
+func (i *deviceBlockIterator) Err() error {
+	return i.err
+}
+
+func (i *deviceBlockIterator) Next() bool {
+	if i.currOffset == 0 {
+		i.currOffset = blockDevice.MetadataSize
+		return i.nextHelper(true)
+	}
+	return i.nextHelper(false)
+}
+
+func (i *deviceBlockIterator) nextHelper(firstRun bool) bool {
+	if i.done {
+		return false
+	}
+	jumpSize := blockDevice.BlockSize + i.db.metadata.TorusBlockSize
+	if !firstRun {
+		i.currOffset += jumpSize
+	}
+searchLoop:
+	for {
+		if i.currOffset >= i.db.deviceSize {
+			i.done = true
+			return false
+		}
+		hdrs, err := i.db.readBlockHeader(i.currOffset)
+		if err != nil {
+			i.err = err
+			return false
+		}
+		for _, h := range hdrs {
+			if h.Location == 0 && !h.IsNil() {
+				i.currBlockRef = torus.BlockRefFromUint64s(h.Volume, h.Inode, h.Index)
+				break searchLoop
+			}
+		}
+		i.currOffset += jumpSize
+	}
+	return true
+}
+
+func (i *deviceBlockIterator) BlockRef() torus.BlockRef {
+	return i.currBlockRef
+}
+
+func (i *deviceBlockIterator) Close() error {
+	return nil
+}
+
+func (d *deviceBlock) BlockSize() uint64 {
+	return d.metadata.TorusBlockSize
+}
+
+func (d *deviceBlock) readMetadata() (*blockDevice.Metadata, error) {
+	// A single 4k block
+	buf := make([]byte, blockDevice.BlockSize)
+	_, err := d.deviceFile.Seek(0, os.SEEK_SET)
+	if err != nil {
+		return nil, err
+	}
+	n, err := d.deviceFile.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+	if uint64(n) != blockDevice.BlockSize {
+		return nil, fmt.Errorf("Read an unexpected number of bytes? %d", n)
+	}
+
+	m := &blockDevice.Metadata{}
+	err = m.Unmarshal(buf)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// findBlockOffset finds the offset into the device a block's header is.
+// Returns the blocks offset, whether or not the block was found, and any errors
+func (d *deviceBlock) findBlockOffset(b torus.BlockRef) (uint64, bool, error) {
+	blockOffset, err := d.findDefaultBlockOffset(b)
+	if err != nil {
+		return 0, false, err
+	}
+
+	return d.findRealBlockOffset(b, blockOffset)
+}
+
+func (d *deviceBlock) findDefaultBlockOffset(b torus.BlockRef) (uint64, error) {
+	numBlockLocations, err := d.numBlockLocations()
+	if err != nil {
+		return 0, err
+	}
+
+	buf := make([]byte, 24)
+	b.ToBytesBuf(buf)
+	h := sha256.New()
+	h.Write(buf)
+	hashedBuf := h.Sum(buf)
+	hashedNum := binary.BigEndian.Uint64(hashedBuf[len(hashedBuf)-8:])
+	blockNum := hashedNum % numBlockLocations
+
+	blockOffset := blockNum*(blockDevice.BlockSize+d.metadata.TorusBlockSize) + blockDevice.MetadataSize
+
+	return blockOffset, nil
+}
+
+func (d *deviceBlock) findRealBlockOffset(b torus.BlockRef, currentBlockOffset uint64) (uint64, bool, error) {
+	hdrs, err := d.readBlockHeader(currentBlockOffset)
+	if err != nil {
+		return 0, false, err
+	}
+	for _, h := range hdrs {
+		if h.Volume == uint64(b.Volume()) && h.Inode == uint64(b.INode) && h.Index == uint64(b.Index) {
+			if h.Location == 0 {
+				return currentBlockOffset, true, nil
+			} else {
+				return d.findRealBlockOffset(b, h.Location)
+			}
+		}
+	}
+
+	return 0, false, nil
+}
+
+func (d *deviceBlock) numBlockLocations() (uint64, error) {
+	return (d.deviceSize - blockDevice.MetadataSize) / (blockDevice.BlockSize + d.metadata.TorusBlockSize), nil
+}
+
+func (d *deviceBlock) incrementUsedBlocks() error {
+	d.metadata.UsedBlocks++
+	return d.writeMetadata()
+}
+
+func (d *deviceBlock) decrementUsedBlocks() error {
+	d.metadata.UsedBlocks--
+	return d.writeMetadata()
+}
+
+func (d *deviceBlock) writeMetadata() error {
+	buf := d.metadata.Marshal()
+	_, err := d.deviceFile.Seek(0, os.SEEK_SET)
+	if err != nil {
+		return err
+	}
+	n, err := d.deviceFile.Write(buf)
+	if err != nil {
+		return err
+	}
+	if n != len(buf) {
+		return fmt.Errorf("Unexpected number of bytes written!! %d", n)
+	}
+	return nil
+}

--- a/storage/block_device/blockHeader.go
+++ b/storage/block_device/blockHeader.go
@@ -1,0 +1,125 @@
+package block_device
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/coreos/torus"
+)
+
+type BlockHeader struct {
+	Volume   uint64
+	Inode    uint64
+	Index    uint64
+	Location uint64
+}
+
+const (
+	BlockHeaderSize = 32 // 4 fields * 8 byte fields
+)
+
+func (b *BlockHeader) Unmarshal(buf []byte) {
+	b.Volume = binary.BigEndian.Uint64(buf[0:8])
+	b.Inode = binary.BigEndian.Uint64(buf[8:16])
+	b.Index = binary.BigEndian.Uint64(buf[16:24])
+	b.Location = binary.BigEndian.Uint64(buf[24:32])
+}
+
+func (b *BlockHeader) Marshal(buf []byte) {
+	binary.BigEndian.PutUint64(buf[0:8], b.Volume)
+	binary.BigEndian.PutUint64(buf[8:16], b.Inode)
+	binary.BigEndian.PutUint64(buf[16:24], b.Index)
+	binary.BigEndian.PutUint64(buf[24:32], b.Location)
+}
+
+func (b *BlockHeader) IsNil() bool {
+	return b.Volume == 0 && b.Inode == 0 && b.Index == 0
+}
+
+func (b *BlockHeader) String() string {
+	return fmt.Sprintf("block header %d:%d:%d:%d", b.Volume, b.Inode, b.Index, b.Location)
+}
+
+func (b *BlockHeader) Equal(b2 *BlockHeader) bool {
+	return b.Volume == b2.Volume && b.Inode == b2.Inode && b.Index == b2.Index && b.Location == b2.Location
+}
+
+type BlockHeaders []*BlockHeader
+
+func NewBlockHeaders() BlockHeaders {
+	bs := make(BlockHeaders, BlockSize/BlockHeaderSize)
+	for i := 0; i < len(bs); i++ {
+		bs[i] = &BlockHeader{}
+	}
+	return bs
+}
+
+func (bs BlockHeaders) Unmarshal(buf []byte) error {
+	maxNumHeaders := len(buf) / BlockHeaderSize
+	if maxNumHeaders > len(bs) {
+		return fmt.Errorf("BlockHeaders.Unmarshal: buffer too large")
+	}
+	for i := 0; i < maxNumHeaders; i++ {
+		n := i * BlockHeaderSize // current offset into buf
+		bs[i].Unmarshal(buf[n : n+32])
+	}
+	return nil
+}
+
+func (bs BlockHeaders) Marshal(buf []byte) error {
+	if len(bs)*BlockHeaderSize > len(buf) {
+		return fmt.Errorf("BlockHeaders.Marshal: buffer too small")
+	}
+	for i := 0; i < len(bs); i++ {
+		n := i * BlockHeaderSize // current offset into buf
+		bs[i].Marshal(buf[n : n+32])
+	}
+	return nil
+}
+
+func (bs BlockHeaders) String() string {
+	ret := ""
+	for i, b := range bs {
+		if b.IsNil() {
+			break
+		}
+		if i != 0 {
+			ret += "--------------------\n"
+		}
+		ret += fmt.Sprintf(" - volume:   %d\n", b.Volume)
+		ret += fmt.Sprintf(" - inode:    %d\n", b.Inode)
+		ret += fmt.Sprintf(" - index:    %d\n", b.Index)
+		ret += fmt.Sprintf(" - location: %d\n", b.Location)
+	}
+	return ret
+}
+
+func (bs BlockHeaders) IsUsed() bool {
+	blockUsed := false
+	for _, b := range bs {
+		if b.Location == 0 && !b.IsNil() {
+			blockUsed = true
+			break
+		}
+	}
+	return blockUsed
+}
+
+func (bs BlockHeaders) Add(b *BlockHeader) error {
+	for i := 0; i < len(bs); i++ {
+		if bs[i].IsNil() {
+			bs[i] = b
+			return nil
+		}
+	}
+	return fmt.Errorf("block header is full: %q", b.String())
+}
+
+func (bs BlockHeaders) Delete(br torus.BlockRef) {
+	for i := 0; i < len(bs); i++ {
+		b := bs[i]
+		if b.Volume == uint64(br.Volume()) && b.Inode == uint64(br.INode) && b.Index == uint64(br.Index) {
+			bs[i] = &BlockHeader{}
+		}
+	}
+}

--- a/storage/block_device/blockHeader_test.go
+++ b/storage/block_device/blockHeader_test.go
@@ -1,0 +1,61 @@
+package block_device
+
+import (
+	"bytes"
+	"testing"
+)
+
+var (
+	volume   uint64 = 0x0101010101010101
+	inode    uint64 = 0x0202020202020202
+	index    uint64 = 0x0303030303030303
+	location uint64 = 0x0404040404040404
+
+	volumeBytes   = []byte{0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01}
+	inodeBytes    = []byte{0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02}
+	indexBytes    = []byte{0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03}
+	locationBytes = []byte{0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04}
+)
+
+func TestBlockHeaderUnmarshal(t *testing.T) {
+	var buf []byte
+	buf = append(buf, volumeBytes...)
+	buf = append(buf, inodeBytes...)
+	buf = append(buf, indexBytes...)
+	buf = append(buf, locationBytes...)
+
+	b := BlockHeader{}
+	b.Unmarshal(buf)
+
+	expectedB := &BlockHeader{
+		Volume:   volume,
+		Inode:    inode,
+		Index:    index,
+		Location: location,
+	}
+
+	if !b.Equal(expectedB) {
+		t.Errorf("block header unmarshalled incorrectly!\ndata: %s\nexpected: %s", b.String(), expectedB.String())
+	}
+}
+
+func TestBlockHeaderMarshal(t *testing.T) {
+	b := &BlockHeader{
+		Volume:   volume,
+		Inode:    inode,
+		Index:    index,
+		Location: location,
+	}
+	buf := make([]byte, BlockHeaderSize)
+	b.Marshal(buf)
+
+	var expectedBuf []byte
+	expectedBuf = append(expectedBuf, volumeBytes...)
+	expectedBuf = append(expectedBuf, inodeBytes...)
+	expectedBuf = append(expectedBuf, indexBytes...)
+	expectedBuf = append(expectedBuf, locationBytes...)
+
+	if !bytes.Equal(buf, expectedBuf) {
+		t.Errorf("block header marshalled incorrectly!\ndata: %v\nexpected: %v", buf, expectedBuf)
+	}
+}

--- a/storage/block_device/constants.go
+++ b/storage/block_device/constants.go
@@ -1,0 +1,9 @@
+package block_device
+
+var (
+	BlockSize    uint64 = 4096 // number of bytes in a device block
+	MetadataSize        = BlockSize
+
+	MagicSentence = []byte("I am a torus block device!")
+	MagicLen      = len(MagicSentence)
+)

--- a/storage/block_device/metadata.go
+++ b/storage/block_device/metadata.go
@@ -1,0 +1,40 @@
+package block_device
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"time"
+)
+
+type Metadata struct {
+	TorusBlockSize     uint64
+	FormattedTimestamp time.Time
+	UsedBlocks         uint64
+}
+
+func (m *Metadata) Marshal() []byte {
+	buf := make([]byte, MetadataSize)
+	for i, b := range MagicSentence {
+		buf[i] = b
+	}
+	binary.BigEndian.PutUint64(buf[MagicLen:MagicLen+8], m.TorusBlockSize)
+	binary.BigEndian.PutUint64(buf[MagicLen+8:MagicLen+16], uint64(m.FormattedTimestamp.Unix()))
+	binary.BigEndian.PutUint64(buf[MagicLen+16:MagicLen+24], m.UsedBlocks)
+
+	return buf
+}
+
+func (m *Metadata) Unmarshal(buf []byte) error {
+	if !bytes.Equal(MagicSentence, buf[:MagicLen]) {
+		return fmt.Errorf("device has not been formatted for torus")
+	}
+
+	m.TorusBlockSize = binary.BigEndian.Uint64(buf[MagicLen : MagicLen+8])
+	timeStampNum := binary.BigEndian.Uint64(buf[MagicLen+8 : MagicLen+16])
+	m.UsedBlocks = binary.BigEndian.Uint64(buf[MagicLen+16 : MagicLen+24])
+
+	m.FormattedTimestamp = time.Unix(int64(timeStampNum), 0)
+
+	return nil
+}

--- a/storage/block_device/metadata_test.go
+++ b/storage/block_device/metadata_test.go
@@ -1,0 +1,54 @@
+package block_device
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+func TestMetadataMarshal(t *testing.T) {
+	m := &Metadata{
+		TorusBlockSize:     512 * 1024,
+		FormattedTimestamp: time.Unix(0x0000000011111111, 0),
+		UsedBlocks:         0x1111111122222222,
+	}
+
+	data := m.Marshal()
+
+	if !bytes.Equal(data[:MagicLen], MagicSentence) {
+		t.Errorf("marshalled data didn't have magic sentence")
+	}
+	// 0x0000000000080000 is 512*1024 in hex
+	if !bytes.Equal(data[MagicLen:MagicLen+8], []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00}) {
+		t.Errorf("block size wasn't expected value")
+	}
+	if !bytes.Equal(data[MagicLen+8:MagicLen+16], []byte{0x00, 0x00, 0x00, 0x00, 0x11, 0x11, 0x11, 0x11}) {
+		t.Errorf("timestamp wasn't expected value")
+	}
+	if !bytes.Equal(data[MagicLen+16:MagicLen+24], []byte{0x11, 0x11, 0x11, 0x11, 0x22, 0x22, 0x22, 0x22}) {
+		t.Errorf("used blocks wasn't expected value")
+	}
+}
+
+func TestMetadataUnmarshal(t *testing.T) {
+	buf := []byte{
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, // block size
+		0x00, 0x00, 0x00, 0x00, 0x11, 0x11, 0x11, 0x11, // time stamp
+		0x11, 0x11, 0x11, 0x11, 0x22, 0x22, 0x22, 0x22, // used blocks
+	}
+	buf = append(MagicSentence, buf...)
+	m := &Metadata{}
+	err := m.Unmarshal(buf)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
+	if m.TorusBlockSize != 512*1024 {
+		t.Errorf("Unmarshalled data didn't have expected block size")
+	}
+	if m.FormattedTimestamp != time.Unix(0x0000000011111111, 0) {
+		t.Errorf("Unmarshalled data didn't have expected timestamp")
+	}
+	if m.UsedBlocks != 0x1111111122222222 {
+		t.Errorf("Unmarshalled data didn't have expected timestamp")
+	}
+}

--- a/storage/block_device/utilities.go
+++ b/storage/block_device/utilities.go
@@ -1,0 +1,21 @@
+package block_device
+
+// #include <fcntl.h>
+// #include <linux/fs.h>
+import "C"
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func GetDeviceSize(deviceFile *os.File) (uint64, error) {
+	var numBlocks int64
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(deviceFile.Fd()), uintptr(C.BLKGETSIZE), uintptr(unsafe.Pointer(&numBlocks)))
+	if errno != 0 {
+		return 0, errno
+	}
+	numBytes := numBlocks * 512
+	return uint64(numBytes), nil
+}

--- a/storage/block_device_test.go
+++ b/storage/block_device_test.go
@@ -1,0 +1,427 @@
+// +build integration
+
+package storage
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/coreos/torus"
+	fsck "github.com/coreos/torus/cmd/fsck.torus/lib"
+	mkfs "github.com/coreos/torus/cmd/mkfs.torus/lib"
+)
+
+func stderr(msg string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, strings.TrimSpace(msg)+"\n", args...)
+}
+
+var lodevice = ""
+
+const torusBlockSize = 1024 * 512 // 512K
+
+type deviceBlockTester struct {
+	db          *deviceBlock
+	backingFile string
+}
+
+func run(cmd string, args ...string) error {
+	stderr("Running: %s %v", cmd, args)
+	command := exec.Command(cmd, args...)
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	return command.Run()
+}
+
+func newDeviceBlockTester(deviceSize uint64) (*deviceBlockTester, error) {
+	stderr("Creating new block device...")
+	dbt := &deviceBlockTester{}
+	f, err := ioutil.TempFile("", "torus")
+	if err != nil {
+		return nil, err
+	}
+	f.Close()
+	dbt.backingFile = f.Name()
+	err = run("dd", "if=/dev/urandom", "of="+dbt.backingFile, "bs=1024", fmt.Sprintf("count=%d", deviceSize/1024))
+	if err != nil {
+		return nil, err
+	}
+
+	stderr("Running: %s, %v", "losetup", "-f")
+	lodeviceBytes, err := exec.Command("losetup", "-f").Output()
+	if err != nil {
+		return nil, err
+	}
+	lodevice = strings.TrimSpace(string(lodeviceBytes))
+
+	err = run("losetup", lodevice, dbt.backingFile)
+	if err != nil {
+		return nil, err
+	}
+	stderr("formatting block device")
+	err = mkfs.Mkfs(mkfs.DefaultBlockSize, true, lodevice)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := torus.Config{
+		DataDir:         "",
+		BlockDevice:     lodevice,
+		StorageSize:     0,
+		MetadataAddress: "",
+		ReadCacheSize:   0,
+		ReadLevel:       0,
+		WriteLevel:      0,
+		TLS:             nil,
+	}
+	meta := torus.GlobalMetadata{
+		BlockSize:        torusBlockSize,
+		DefaultBlockSpec: nil,
+		INodeReplication: 0,
+	}
+
+	db, err := newBlockDeviceBlockStore(lodevice, cfg, meta)
+	dbt.db = db.(*deviceBlock)
+
+	return dbt, nil
+}
+
+func (d *deviceBlockTester) Close(t *testing.T) error {
+	stderr("Checking for block device corruption...")
+	err := fsck.Fsck(true, lodevice, mkfs.DefaultBlockSize)
+	if err != nil {
+		t.Errorf("fsck failed!")
+	}
+
+	stderr("Cleaning up block device")
+	d.db.Close()
+	err = exec.Command("losetup", "-d", lodevice).Run()
+	if err != nil {
+		return err
+	}
+	err = os.Remove(d.backingFile)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type operation interface {
+	perform(d *deviceBlock) error
+	String() string
+}
+
+type writeOp struct {
+	b           torus.BlockRef
+	data        []byte
+	errExpected bool
+}
+
+func (w *writeOp) String() string {
+	return fmt.Sprintf("write to block ref %q, errExpected=%t", w.b.String(), w.errExpected)
+}
+
+func (w *writeOp) perform(d *deviceBlock) error {
+	err := d.WriteBlock(context.TODO(), w.b, w.data)
+	if w.errExpected {
+		if err == nil {
+			return fmt.Errorf("didn't error when it was expected to")
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	r := &readOp{w.b, w.data, false}
+	return r.perform(d)
+}
+
+type readOp struct {
+	b            torus.BlockRef
+	expectedData []byte
+	errExpected  bool
+}
+
+func (r *readOp) String() string {
+	return fmt.Sprintf("read to block ref %q, errExpected=%t", r.b.String(), r.errExpected)
+}
+
+func (r *readOp) perform(d *deviceBlock) error {
+	data, err := d.GetBlock(context.TODO(), r.b)
+	if r.errExpected {
+		if err == nil {
+			return fmt.Errorf("didn't error when it was expected to")
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(data, r.expectedData) {
+		return fmt.Errorf("read operation didn't return expected data for block ref %q\nexpected first 8 bytes: %v\nactual first 8 bytes: %v", r.b.String(), r.expectedData[:8], data[:8])
+	}
+	return nil
+}
+
+type deleteOp struct {
+	b           torus.BlockRef
+	errExpected bool
+}
+
+func (e *deleteOp) String() string {
+	return fmt.Sprintf("delete of block ref %q, errExpected=%t", e.b.String(), e.errExpected)
+}
+
+func (e *deleteOp) perform(d *deviceBlock) error {
+	err := d.DeleteBlock(context.TODO(), e.b)
+	if e.errExpected {
+		if err == nil {
+			return fmt.Errorf("didn't error when it was expected to")
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	h := &hasOp{e.b, false, false}
+	return h.perform(d)
+}
+
+type hasOp struct {
+	b           torus.BlockRef
+	expectedVal bool
+	errExpected bool
+}
+
+func (h *hasOp) perform(d *deviceBlock) error {
+	hasBlock, err := d.HasBlock(context.TODO(), h.b)
+	if h.errExpected {
+		if err == nil {
+			return fmt.Errorf("didn't error when it was expected to")
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if hasBlock != h.expectedVal {
+		return fmt.Errorf("has block operation returned %t instead of expected value of %t for block ref %q", hasBlock, h.expectedVal, h.b.String)
+	}
+	return nil
+}
+
+func (h *hasOp) String() string {
+	return fmt.Sprintf("has check of block ref %q, expected=%t, errExpected=%t", h.b.String(), h.expectedVal, h.errExpected)
+}
+
+func TestBlockDeviceStorage(t *testing.T) {
+	dbt, err := newDeviceBlockTester(1024 * 1024 * 1024) // 1 GiB
+	if err != nil {
+		t.Fatalf("newDeviceBlockTester: %v\n", err)
+	}
+	defer func() {
+		err = dbt.Close(t)
+		if err != nil {
+			t.Fatalf("dbt.Close(): %v\n", err)
+		}
+	}()
+
+	order := binary.LittleEndian
+	zeros := make([]byte, torusBlockSize)
+	data1 := make([]byte, torusBlockSize)
+	order.PutUint64(data1[0:8], 0x10)
+	data2 := make([]byte, torusBlockSize)
+	order.PutUint64(data2[0:8], 0x100)
+	data3 := make([]byte, torusBlockSize)
+	order.PutUint64(data3[0:8], 0x1000)
+	data4 := make([]byte, torusBlockSize)
+	order.PutUint64(data4[0:8], 0x10000)
+	data5 := make([]byte, torusBlockSize)
+	order.PutUint64(data5[0:8], 0x100000)
+
+	for _, o := range []operation{
+		// None of these blocks should exist yet
+		&hasOp{torus.BlockRefFromUint64s(1, 0, 0), false, false},
+		&hasOp{torus.BlockRefFromUint64s(1, 0, 1), false, false},
+		&hasOp{torus.BlockRefFromUint64s(1, 0, 2), false, false},
+		&hasOp{torus.BlockRefFromUint64s(1, 0, 3), false, false},
+		&hasOp{torus.BlockRefFromUint64s(1, 0, 4), false, false},
+
+		// Write out some data
+		&writeOp{torus.BlockRefFromUint64s(1, 0, 0), data1, false},
+		&writeOp{torus.BlockRefFromUint64s(1, 0, 1), data2, false},
+		&writeOp{torus.BlockRefFromUint64s(1, 0, 2), data3, false},
+		&writeOp{torus.BlockRefFromUint64s(1, 0, 3), data4, false},
+		&writeOp{torus.BlockRefFromUint64s(1, 0, 4), data5, false},
+
+		// Overwrite the data
+		&writeOp{torus.BlockRefFromUint64s(1, 0, 0), data2, false},
+		&writeOp{torus.BlockRefFromUint64s(1, 0, 1), data3, false},
+		&writeOp{torus.BlockRefFromUint64s(1, 0, 2), data4, false},
+		&writeOp{torus.BlockRefFromUint64s(1, 0, 3), data5, false},
+		&writeOp{torus.BlockRefFromUint64s(1, 0, 4), data1, false},
+
+		// Now all of these blocks should exist
+		&hasOp{torus.BlockRefFromUint64s(1, 0, 0), true, false},
+		&hasOp{torus.BlockRefFromUint64s(1, 0, 1), true, false},
+		&hasOp{torus.BlockRefFromUint64s(1, 0, 2), true, false},
+		&hasOp{torus.BlockRefFromUint64s(1, 0, 3), true, false},
+		&hasOp{torus.BlockRefFromUint64s(1, 0, 4), true, false},
+
+		// And these blocks should still not exist
+		&hasOp{torus.BlockRefFromUint64s(1, 0, 5), false, false},
+		&hasOp{torus.BlockRefFromUint64s(1, 1, 0), false, false},
+		&hasOp{torus.BlockRefFromUint64s(2, 0, 0), false, false},
+
+		// Reading an invalid block should error
+		&readOp{torus.BlockRefFromUint64s(2, 0, 0), nil, true},
+
+		// A block that's all zeros should still exist
+		&writeOp{torus.BlockRefFromUint64s(2, 0, 0), zeros, false},
+		&hasOp{torus.BlockRefFromUint64s(2, 0, 0), true, false},
+
+		// If we delete a block, it shouldn't exist and should error when read
+		&deleteOp{torus.BlockRefFromUint64s(1, 0, 0), false},
+		&hasOp{torus.BlockRefFromUint64s(1, 0, 0), false, false},
+		&readOp{torus.BlockRefFromUint64s(1, 0, 0), nil, true},
+
+		// Deleting an invalid block should error
+		&deleteOp{torus.BlockRefFromUint64s(1, 0, 0), true},
+	} {
+		err := o.perform(dbt.db)
+		if err != nil {
+			t.Errorf("error encountered when performing %s\nerror: %v", o.String(), err)
+		}
+	}
+}
+
+func TestFillUpDevice(t *testing.T) {
+	dbt, err := newDeviceBlockTester(1024 * 1024 * 100) // 100 MiB
+	if err != nil {
+		t.Fatalf("newDeviceBlockTester: %v\n", err)
+	}
+	defer func() {
+		err = dbt.Close(t)
+		if err != nil {
+			t.Fatalf("dbt.Close(): %v\n", err)
+		}
+	}()
+
+	order := binary.LittleEndian
+
+	// We should be able to write dbt.db.NumBlocks() blocks to the device
+	var i uint64
+	for i = 1; i <= dbt.db.NumBlocks(); i++ {
+		buf := make([]byte, torusBlockSize)
+		order.PutUint64(buf[0:8], i)
+		w := &writeOp{torus.BlockRefFromUint64s(i, i, i), buf, false}
+		err := w.perform(dbt.db)
+		if err != nil {
+			t.Errorf("error encountered when performing %s\nerror: %v", w.String(), err)
+		}
+	}
+
+	data := make([]byte, torusBlockSize)
+	order.PutUint64(data, 0x0101010101010101)
+
+	// Writing one more block should fail
+	w := &writeOp{torus.BlockRefFromUint64s(1, 0, 0), data, true}
+	err = w.perform(dbt.db)
+	if err != nil {
+		t.Errorf("error encountered when performing %s\nerror: %v", w.String(), err)
+	}
+
+	// Deleting one of the blocks should allow us to then write one more block
+	d := &deleteOp{torus.BlockRefFromUint64s(1, 1, 1), false}
+	err = d.perform(dbt.db)
+	if err != nil {
+		t.Errorf("error encountered when performing %s\nerror: %v", d.String(), err)
+	}
+
+	// And with that block deleted, we should be able to successfully write one
+	// more block
+	w.errExpected = false
+	err = w.perform(dbt.db)
+	if err != nil {
+		t.Errorf("error encountered when performing %s\nerror: %v", w.String(), err)
+	}
+}
+
+func TestBlockDeviceBlockIterator(t *testing.T) {
+	dbt, err := newDeviceBlockTester(1024 * 1024 * 100) // 100 MiB
+	if err != nil {
+		t.Fatalf("newDeviceBlockTester: %v\n", err)
+	}
+	defer func() {
+		err = dbt.Close(t)
+		if err != nil {
+			t.Fatalf("dbt.Close(): %v\n", err)
+		}
+	}()
+	bi := dbt.db.BlockIterator()
+
+	// The device should be empty now
+	val := bi.BlockRef()
+	if !val.IsZero() {
+		t.Errorf("block iterator returned value when it shouldn't have: %q", val.String())
+	}
+	hasNext := bi.Next()
+	if hasNext {
+		t.Errorf("block iterator advanced when it shouldn't have")
+	}
+	err = bi.Err()
+	if err != nil {
+		t.Errorf("block iterator errored when it shouldn't have: %v", err)
+	}
+	err = bi.Close()
+	if err != nil {
+		t.Errorf("block iterator errored on closing when it shouldn't have: %v", err)
+	}
+
+	// Let's fill up the device
+	order := binary.LittleEndian
+	var i uint64
+	for i = 1; i <= dbt.db.NumBlocks(); i++ {
+		buf := make([]byte, torusBlockSize)
+		order.PutUint64(buf[0:8], i)
+		w := &writeOp{torus.BlockRefFromUint64s(i, i, i), buf, false}
+		err := w.perform(dbt.db)
+		if err != nil {
+			t.Errorf("error encountered when performing %s\nerror: %v", w.String(), err)
+		}
+	}
+
+	// Now let's iterate over all the blocks again, checking that we see all of
+	// them
+	blocksSeen := make([]bool, dbt.db.NumBlocks())
+	bi = dbt.db.BlockIterator()
+	for bi.Next() {
+		if err := bi.Err(); err != nil {
+			t.Errorf("block iterator errored when it shouldn't have: %v", err)
+			break
+		}
+		br := bi.BlockRef()
+		index := int(br.Index) - 1 // the block refs were 1 indexed, hence the -1
+		if blocksSeen[index] {
+			t.Errorf("block iterator returned this block ref twice: %q", br.String())
+		}
+		blocksSeen[index] = true
+	}
+	if err := bi.Close(); err != nil {
+		t.Errorf("block iterator errored on closing when it shouldn't have: %v", err)
+	}
+
+	// Have we seen all of the block refs?
+	for i, val := range blocksSeen {
+		if !val {
+			t.Errorf("we never saw block ref %x", i+1) // Again, the block refs are 1 indexed
+		}
+	}
+}


### PR DESCRIPTION
This commit adds support for using a block device as the backing storage for
torusd.

Two utilities have been added, mkfs.torus and fsck.torus, to format a block
device for use by torus, and for checking the consistency of a formatted block
device, respectively.

There is a metadata section of size 512 bytes written to the beginning of the
disk, and the rest of the disk is used to store data.

Each location on the disk in which data can be stored has two things: block
headers of size 512 bytes, and the actual data, whose size is determined by the
torus cluster's block size.

When given a block ref, the location of the data is determined by feeding 24
bits comprised of the block ref's volume, inode, and index through sha256,
converting the last 8 bytes into a uint64.

The block headers are simply a series of 32 bit chunks, containing the three
fields from a block ref and a location field. The location field will either be
0, signifying the data for this block ref is at this location, or a non-zero
integer, which is the location of a different set of block headers to go to.

When writing a block, if the default location is used for a preexisting block
(so, a hash collision), linear probing is then used to find the next free
location to use.

Fixes https://github.com/coreos/torus/issues/171.
