### PR TITLE
rebalance: Tick returns nil explicitly

### DIFF
--- a/distributor/rebalance/tick.go
+++ b/distributor/rebalance/tick.go
@@ -121,9 +121,8 @@ func (r *rebalancer) Tick() (int, error) {
 	}
 	r.bs.Flush()
 
-	var outerr error
 	if itDone {
-		outerr = io.EOF
+		return n, io.EOF
 	}
-	return n, outerr
+	return n, nil
 }


### PR DESCRIPTION
- This patch stops using variable `outerr` and return `nil` or `io.EOF` explicitly, since `outerr` is never assigned "error".
