### PR TITLE
file: tiny: remove ErrAgain and retry

### DIFF
--- a/file.go
+++ b/file.go
@@ -114,9 +114,6 @@ func (f *File) openWrite() error {
 	vid := VolumeID(f.volume.Id)
 	newINode, err := f.srv.MDS.CommitINodeIndex(vid)
 	if err != nil {
-		if err == ErrAgain {
-			return f.openWrite()
-		}
 		return err
 	}
 	f.writeINodeRef = NewINodeRef(VolumeID(vid), newINode)


### PR DESCRIPTION
Remove `ErrAgain` from `openWrite()`, since ErrAgain is not returned and `CommitINodeIndex()` retry through `AtomicModifyKey()`.
