### PR TITLE
torusblk: output common message when attached volume to device and started loop

### DIFF
--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -178,7 +178,8 @@ Specifying `/dev/nbd0` is optional -- it will pick the first available device if
 
 The mount process is similar to FUSE for a block device; it will disconnect when killed, so make sure it's synced and unmounted.
 
-At this point, you have a replicated, highly-available block device connected to your machine. You can format it and mount it using the standard tools you expect:
+If you can see the message `Attached to XXX. Server loop begins ... `, then you have a replicated, highly-available block device connected to your machine.
+You can format it and mount it using the standard tools you expect:
 
 ```
 sudo mkfs.ext4 /dev/nbd0

--- a/block/aoe/aoe.go
+++ b/block/aoe/aoe.go
@@ -142,7 +142,7 @@ func (s *Server) Serve(iface *Interface) error {
 		}
 	}
 
-	clog.Tracef("beginning server loop on %+v", iface)
+	fmt.Printf("Attached to AoE device (%s, Major: %d, Minor: %d). Server loop begins ... \n", iface.Name, s.major, s.minor)
 
 	// Start goroutine to sync device at regular intervals, and halt when
 	// the Server's Close method is called.

--- a/cmd/torusblk/nbd.go
+++ b/cmd/torusblk/nbd.go
@@ -121,11 +121,10 @@ func connectNBD(srv *torus.Server, f *block.BlockFile, target string, closer cha
 		target = t
 	}
 
-	dev, err := handle.OpenDevice(target)
+	_, err := handle.OpenDevice(target)
 	if err != nil {
 		return err
 	}
-	fmt.Println("Connected to", dev)
 
 	go func(n *nbd.NBD) {
 		<-closer

--- a/internal/nbd/nbd.go
+++ b/internal/nbd/nbd.go
@@ -206,6 +206,7 @@ func (nbd *NBD) Serve() error {
 		}
 	}
 
+	fmt.Printf("Attached to %s. Server loop begins ... \n", nbd.nbd.Name())
 	c := &serverConn{
 		rw: os.NewFile(uintptr(nbd.socket), "<nbd socket>"),
 	}

--- a/internal/tcmu/connect.go
+++ b/internal/tcmu/connect.go
@@ -48,7 +48,7 @@ func ConnectAndServe(f *block.BlockFile, name string, closer chan bool) error {
 		return err
 	}
 	defer d.Close()
-	fmt.Printf("go-tcmu attached to %s/%s\n", devPath, name)
+	fmt.Printf("Attached to %s/%s. Server loop begins ... \n", devPath, name)
 	<-closer
 	return nil
 }


### PR DESCRIPTION
fixes https://github.com/coreos/torus/issues/355