### PR TITLE
aoe: output header arg with trace level

### DIFF
--- a/block/aoe/aoe.go
+++ b/block/aoe/aoe.go
@@ -190,8 +190,8 @@ func (s *Server) Serve(iface *Interface) error {
 			continue
 		}
 
-		clog.Debugf("recv %d %s %+v", n, addr, f.Header)
-		//clog.Debugf("recv arg %+v", f.Header.Arg)
+		clog.Tracef("recv: %d %s %+v", n, addr, f.Header)
+		clog.Tracef("recv arg: %+v", f.Header.Arg)
 
 		s.handleFrame(addr, iface, &f)
 	}
@@ -242,7 +242,7 @@ func (s *Server) handleFrame(from net.Addr, iface *Interface, f *Frame) (int, er
 		return n, nil
 	case aoe.CommandQueryConfigInformation:
 		cfgarg := f.Header.Arg.(*aoe.ConfigArg)
-		clog.Debugf("cfgarg: %+v", cfgarg)
+		clog.Tracef("cfgarg: %+v", cfgarg)
 
 		switch cfgarg.Command {
 		case aoe.ConfigCommandRead:

--- a/block/aoe/frame.go
+++ b/block/aoe/frame.go
@@ -65,8 +65,8 @@ func (fs *FrameSender) Send(hdr *aoe.Header) (int, error) {
 		panic(err)
 	}
 
-	clog.Debugf("send %d %s %+v", len(ebuf), fs.dst, hdr)
-	//clog.Debugf("send arg %+v", hdr.Arg)
+	clog.Tracef("send: %d %s %+v", len(ebuf), fs.dst, hdr)
+	clog.Tracef("send arg: %+v", hdr.Arg)
 
 	return fs.conn.WriteTo(ebuf, &raw.Addr{HardwareAddr: fs.dst})
 }


### PR DESCRIPTION
Currently, `torusblk aoe vol_name lo 1 1`  with `--debug` keep outputting the data, address and header and they are too much. This patch enables to output Header arguments, but they are moved to `Trace` level.