### PR TITLE
aoe: remove default options to specify major and minor numbers

### DIFF
--- a/block/aoe/aoe.go
+++ b/block/aoe/aoe.go
@@ -50,20 +50,9 @@ type ServerOptions struct {
 	Minor uint8
 }
 
-// DefaultServerOptions is the default ServerOptions configuration used
-// by NewServer when none is specified.
-var DefaultServerOptions = &ServerOptions{
-	Major: 1,
-	Minor: 1,
-}
-
 // NewServer creates a new Server which utilizes the specified block volume.
 // If options is nil, DefaultServerOptions will be used.
 func NewServer(b *block.BlockVolume, options *ServerOptions) (*Server, error) {
-	if options == nil {
-		options = DefaultServerOptions
-	}
-
 	f, err := b.OpenBlockFile()
 	if err != nil {
 		return nil, err

--- a/block/aoe/aoe_test.go
+++ b/block/aoe/aoe_test.go
@@ -298,7 +298,10 @@ func testAoEServer(t *testing.T) (response io.Reader, request io.Writer, run fun
 		t.Fatalf("error opening block volume: %v", err)
 	}
 
-	as, err := NewServer(vol, nil)
+	as, err := NewServer(vol, &ServerOptions{
+		Major: 1,
+		Minor: 1,
+	})
 	if err != nil {
 		t.Fatalf("error opening AoE server: %v", err)
 	}


### PR DESCRIPTION
- This patch removes DefaultServerOptions struct which is used by only one test case.