### PR TITLE
distributor: tiny: output error and retry count in readWithBackoff

### DIFF
--- a/distributor/storage.go
+++ b/distributor/storage.go
@@ -70,6 +70,7 @@ func (d *Distributor) readWithBackoff(ctx context.Context, ref torus.BlockRef, p
 		if err == nil {
 			return blk, err
 		}
+		clog.Warningf("failed peers, retry count %d: %v", i, err)
 	}
 	return nil, ErrNoPeersBlock
 }


### PR DESCRIPTION
distributor: output error and retry count in readWithBackoff

Currently readWithBackoff() retry to get blocks without warning
messages. This patch changes to output warning message when get blocks
failed from remote peers.