### PR TITLE
distributor: return ErrNoPeer instead of ErrBlockUnavailable when get connection failed

### DIFF
--- a/distributor/client.go
+++ b/distributor/client.go
@@ -131,7 +131,7 @@ func (d *distClient) GetBlock(ctx context.Context, uuid string, b torus.BlockRef
 func (d *distClient) PutBlock(ctx context.Context, uuid string, b torus.BlockRef, data []byte) error {
 	conn := d.getConn(uuid)
 	if conn == nil {
-		return torus.ErrBlockUnavailable
+		return torus.ErrNoPeer
 	}
 	err := conn.PutBlock(ctx, b, data)
 	if err != nil {


### PR DESCRIPTION
distributor: return ErrNoPeer when get connection failed

Since getConn() tries to get connection, the error should be no peers
rather than block unavailable. On top of that, as all of other getConn()
return ErrNoPeer, it should have consistent policy.