### PR TITLE
mfile: output data with correct format

### DIFF
--- a/storage/mfile.go
+++ b/storage/mfile.go
@@ -243,7 +243,7 @@ func (m *mfileBlock) WriteBlock(_ context.Context, s torus.BlockRef, data []byte
 		olddata := m.dataFile.GetBlock(uint64(v))
 		if !bytes.Equal(olddata, data) {
 			clog.Error("getting wrong data for block: ", s)
-			clog.Errorf("%s, %s", olddata[:10], data[:10])
+			clog.Errorf("old: %v, new: %v", olddata[:10], data[:10])
 			return torus.ErrExists
 		}
 		// Not an error, if we already have it


### PR DESCRIPTION
mfile: output data with correct format

When same block but different data exists, it produces error log with
the differnt data. Currently, these data output with string format
even though they are byte data. This patch changes to data format
correctly.

current log output:
~~~
2016-12-15 13:12:26.254596 E | storage: , 33
~~~

this patch fixes as:
~~~
2016-12-15 13:16:11.139927 E | storage: old: [0 0 0 0 0 0 0 0 0 0], new: [0 0 1 0 0 0 4 0 51 51]
~~~